### PR TITLE
feat/#2: 회원 관련 엔티티 추가

### DIFF
--- a/initdb/02-create-test-db.sql
+++ b/initdb/02-create-test-db.sql
@@ -3,3 +3,8 @@ SELECT 'CREATE DATABASE walkit_test OWNER walkit'
     WHERE NOT EXISTS (
   SELECT FROM pg_database WHERE datname = 'walkit_test'
 )\gexec
+
+-- Install PostGIS
+\c walkit_test
+CREATE EXTENSION IF NOT EXISTS postgis;
+CREATE EXTENSION IF NOT EXISTS postgis_topology;

--- a/src/main/java/life/walkit/server/global/BaseEntity.java
+++ b/src/main/java/life/walkit/server/global/BaseEntity.java
@@ -1,0 +1,28 @@
+package life.walkit.server.global;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "modified_at", nullable = false)
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean deleted = false;
+}

--- a/src/main/java/life/walkit/server/global/config/JpaConfig.java
+++ b/src/main/java/life/walkit/server/global/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package life.walkit.server.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/life/walkit/server/global/error/core/BaseException.java
+++ b/src/main/java/life/walkit/server/global/error/core/BaseException.java
@@ -1,0 +1,19 @@
+package life.walkit.server.global.error.core;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BaseException extends RuntimeException {
+
+  private final ErrorCode errorCode;
+
+  public BaseException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public BaseException(ErrorCode errorCode, Object ... args) {
+    super(errorCode.getMessage(args));
+    this.errorCode = errorCode;
+  }
+}

--- a/src/main/java/life/walkit/server/global/error/core/ErrorCode.java
+++ b/src/main/java/life/walkit/server/global/error/core/ErrorCode.java
@@ -1,0 +1,12 @@
+package life.walkit.server.global.error.core;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+    String getMessage();
+
+    default String getMessage(Object... args){
+        return String.format(this.getMessage(), args);
+    }
+}

--- a/src/main/java/life/walkit/server/global/error/core/ErrorResponse.java
+++ b/src/main/java/life/walkit/server/global/error/core/ErrorResponse.java
@@ -1,0 +1,24 @@
+package life.walkit.server.global.error.core;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+    private final int status;
+    private final String message;
+    private final String originalErrorBody; // 추가
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getStatus().value(), errorCode.getMessage(), null);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message) {
+        return new ErrorResponse(errorCode.getStatus().value(), message, null);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, String message, String originalErrorBody) {
+        return new ErrorResponse(errorCode.getStatus().value(), message, originalErrorBody);
+    }
+}

--- a/src/main/java/life/walkit/server/member/entity/Friend.java
+++ b/src/main/java/life/walkit/server/member/entity/Friend.java
@@ -48,10 +48,16 @@ public class Friend extends BaseEntity {
     }
 
     public void approve() {
+        if (this.status != FriendStatus.PENDING && this.status != FriendStatus.REJECTED) {
+            throw new MemberException(MemberErrorCode.FRIEND_STATUS_INVALID);
+        }
         this.status = FriendStatus.APPROVED;
     }
 
     public void reject() {
+        if (this.status != FriendStatus.PENDING) {
+            throw new MemberException(MemberErrorCode.FRIEND_STATUS_INVALID);
+        }
         this.status = FriendStatus.REJECTED;
     }
 }

--- a/src/main/java/life/walkit/server/member/entity/Friend.java
+++ b/src/main/java/life/walkit/server/member/entity/Friend.java
@@ -1,0 +1,48 @@
+package life.walkit.server.member.entity;
+
+import jakarta.persistence.*;
+import life.walkit.server.global.BaseEntity;
+import life.walkit.server.member.entity.enums.FriendStatus;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "friend")
+public class Friend extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "friend_id")
+    private Long friendId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "partner_id", nullable = false)
+    private Member partner;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private FriendStatus status;
+
+    @Builder
+    public Friend(Member member, Member partner) {
+        this.member = member;
+        this.partner = partner;
+        this.status = FriendStatus.PENDING;
+    }
+
+    public void approve() {
+        this.status = FriendStatus.APPROVED;
+    }
+
+    public void reject() {
+        this.status = FriendStatus.REJECTED;
+    }
+}

--- a/src/main/java/life/walkit/server/member/entity/Friend.java
+++ b/src/main/java/life/walkit/server/member/entity/Friend.java
@@ -3,6 +3,8 @@ package life.walkit.server.member.entity;
 import jakarta.persistence.*;
 import life.walkit.server.global.BaseEntity;
 import life.walkit.server.member.entity.enums.FriendStatus;
+import life.walkit.server.member.error.MemberException;
+import life.walkit.server.member.error.enums.MemberErrorCode;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,7 +13,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "friend")
+@Table(name = "friend",
+    uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"member_id", "partner_id"})
+    }
+)
 public class Friend extends BaseEntity {
 
     @Id
@@ -33,6 +39,9 @@ public class Friend extends BaseEntity {
 
     @Builder
     public Friend(Member member, Member partner) {
+        if (member.equals(partner)) {
+            throw new MemberException(MemberErrorCode.SELF_FRIEND_REQUEST);
+        }
         this.member = member;
         this.partner = partner;
         this.status = FriendStatus.PENDING;

--- a/src/main/java/life/walkit/server/member/entity/Member.java
+++ b/src/main/java/life/walkit/server/member/entity/Member.java
@@ -1,0 +1,42 @@
+package life.walkit.server.member.entity;
+
+import jakarta.persistence.*;
+import life.walkit.server.global.BaseEntity;
+import life.walkit.server.member.entity.enums.MemberRole;
+import life.walkit.server.member.entity.enums.MemberStatus;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "member")
+public class Member extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "email", nullable = false, unique = true)
+    private String email;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "nickname", nullable = false, unique = true)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private MemberStatus status;
+
+    @Column(name = "location", columnDefinition = "geometry(Point, 4326)")
+    private Point location;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private MemberRole role;
+}

--- a/src/main/java/life/walkit/server/member/entity/Member.java
+++ b/src/main/java/life/walkit/server/member/entity/Member.java
@@ -5,6 +5,7 @@ import life.walkit.server.global.BaseEntity;
 import life.walkit.server.member.entity.enums.MemberRole;
 import life.walkit.server.member.entity.enums.MemberStatus;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.locationtech.jts.geom.Point;
@@ -39,4 +40,15 @@ public class Member extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
     private MemberRole role;
+
+    @Builder
+    public Member(String email, String name, String nickname, MemberStatus status, Point location, MemberRole role) {
+        this.email = email;
+        this.name = name;
+        this.nickname = nickname;
+        this.status = status;
+        this.location = location;
+        this.role = role;
+    }
+
 }

--- a/src/main/java/life/walkit/server/member/entity/enums/FriendStatus.java
+++ b/src/main/java/life/walkit/server/member/entity/enums/FriendStatus.java
@@ -1,0 +1,7 @@
+package life.walkit.server.member.entity.enums;
+
+public enum FriendStatus {
+    PENDING,
+    APPROVED,
+    REJECTED,
+}

--- a/src/main/java/life/walkit/server/member/entity/enums/MemberRole.java
+++ b/src/main/java/life/walkit/server/member/entity/enums/MemberRole.java
@@ -1,0 +1,6 @@
+package life.walkit.server.member.entity.enums;
+
+public enum MemberRole {
+    USER,
+    ADMIN,
+}

--- a/src/main/java/life/walkit/server/member/entity/enums/MemberStatus.java
+++ b/src/main/java/life/walkit/server/member/entity/enums/MemberStatus.java
@@ -1,0 +1,7 @@
+package life.walkit.server.member.entity.enums;
+
+public enum MemberStatus {
+    OFFLINE,
+    ONLINE,
+    WALKING,
+}

--- a/src/main/java/life/walkit/server/member/error/MemberException.java
+++ b/src/main/java/life/walkit/server/member/error/MemberException.java
@@ -1,0 +1,11 @@
+package life.walkit.server.member.error;
+
+import life.walkit.server.global.error.core.BaseException;
+import life.walkit.server.global.error.core.ErrorCode;
+
+public class MemberException extends BaseException {
+
+    public MemberException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/life/walkit/server/member/error/enums/MemberErrorCode.java
+++ b/src/main/java/life/walkit/server/member/error/enums/MemberErrorCode.java
@@ -1,0 +1,26 @@
+package life.walkit.server.member.error.enums;
+
+import life.walkit.server.global.error.core.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+    FRIEND_REQUEST_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "상대방과의 친구 신청이 이미 존재합니다."),
+    SELF_FRIEND_REQUEST(HttpStatus.BAD_REQUEST, "본인에게 친구 신청할 수 없습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return "[MEMBER ERROR] " + message;
+    }
+}

--- a/src/main/java/life/walkit/server/member/error/enums/MemberErrorCode.java
+++ b/src/main/java/life/walkit/server/member/error/enums/MemberErrorCode.java
@@ -9,7 +9,8 @@ public enum MemberErrorCode implements ErrorCode {
 
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
     FRIEND_REQUEST_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "상대방과의 친구 신청이 이미 존재합니다."),
-    SELF_FRIEND_REQUEST(HttpStatus.BAD_REQUEST, "본인에게 친구 신청할 수 없습니다.");
+    SELF_FRIEND_REQUEST(HttpStatus.BAD_REQUEST, "본인에게 친구 신청할 수 없습니다."),
+    FRIEND_STATUS_INVALID(HttpStatus.BAD_REQUEST, "친구 신청 승인 또는 거절시 상태가 잘못되었습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## #️⃣연관된 이슈

#2 
Closes #2

## 📝작업 내용

회원 Entity 클래스와 친구 Entity 클래스를 추가하였습니다.

createdAt과 modifiedAt, deleted의 경우 자동으로 관리하기 위해 `BaseEntity`를 정의하여 JPAAuditing 기능으로 자동 업데이트되도록 설정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 회원 정보를 나타내는 Member 엔티티가 추가되었습니다.
  * 친구 관계를 관리하는 Friend 엔티티가 도입되었습니다.
  * 회원 상태, 역할, 친구 요청 상태를 위한 Enum 타입이 새로 추가되었습니다.
  * 엔티티 생성 및 수정 시각, 삭제 여부를 자동으로 관리하는 기능이 적용되었습니다.
  * 회원 관련 예외 처리 및 표준화된 에러 코드 체계가 도입되었습니다.

* **설정**
  * JPA 감사(Auditing) 기능이 활성화되어 엔티티의 생성 및 수정 시각이 자동으로 기록됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->