### PR TITLE
Feat/#16: Spring Security 및 OAuth 회원가입 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,8 @@ dependencies {
      */
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-//    implementation 'org.springframework.boot:spring-boot-starter-security'
-//    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation 'org.springframework.boot:spring-boot-starter-hateoas'
 
     /**

--- a/src/main/java/life/walkit/server/WalkitServerApplication.java
+++ b/src/main/java/life/walkit/server/WalkitServerApplication.java
@@ -2,8 +2,10 @@ package life.walkit.server;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class WalkitServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/life/walkit/server/auth/controller/AuthController.java
+++ b/src/main/java/life/walkit/server/auth/controller/AuthController.java
@@ -1,16 +1,24 @@
 package life.walkit.server.auth.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import life.walkit.server.auth.dto.enums.AuthResponse;
+import life.walkit.server.auth.entity.enums.JwtTokenType;
+import life.walkit.server.auth.jwt.JwtTokenProperties;
 import life.walkit.server.auth.service.AuthService;
 import life.walkit.server.global.response.BaseResponse;
+import life.walkit.server.global.util.CookieUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Arrays;
 
 @Slf4j
 @Controller
@@ -19,6 +27,26 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class AuthController {
 
     private final AuthService authService;
+    private final JwtTokenProperties jwtTokenProperties;
+
+    @PostMapping("/logout")
+    public ResponseEntity<BaseResponse> logout(HttpServletResponse response) {
+
+        // 액세스 토큰과 리프레시 토큰을 쿠키에서 제거
+        Arrays.stream(JwtTokenType.values()).forEach(tokenType ->
+                response.addHeader(
+                        HttpHeaders.SET_COOKIE,
+                        CookieUtils.deleteCookie(
+                                tokenType.name(),
+                                true,
+                                "None",
+                                jwtTokenProperties.domain()
+                        ).toString()
+                )
+        );
+
+        return BaseResponse.toResponseEntity(AuthResponse.LOGOUT_SUCCESS);
+    }
 
     @GetMapping("/me")
     public ResponseEntity<BaseResponse> getCurrentUser(@AuthenticationPrincipal UserDetails member) {

--- a/src/main/java/life/walkit/server/auth/controller/AuthController.java
+++ b/src/main/java/life/walkit/server/auth/controller/AuthController.java
@@ -1,5 +1,8 @@
 package life.walkit.server.auth.controller;
 
+import life.walkit.server.auth.dto.enums.AuthResponse;
+import life.walkit.server.auth.service.AuthService;
+import life.walkit.server.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -9,19 +12,19 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.util.Map;
-
 @Slf4j
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    @GetMapping("/me")
-    public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal UserDetails member) {
-        if (member == null)
-            return ResponseEntity.ok(Map.of("status", "not logged in"));
+    private final AuthService authService;
 
-        return ResponseEntity.ok(Map.of("email logged in", member.getUsername()));
+    @GetMapping("/me")
+    public ResponseEntity<BaseResponse> getCurrentUser(@AuthenticationPrincipal UserDetails member) {
+        return BaseResponse.toResponseEntity(
+                AuthResponse.GET_CURRENT_MEMBER_SUCCESS,
+                authService.getCurrentUser(member.getUsername())
+        );
     }
 }

--- a/src/main/java/life/walkit/server/auth/controller/AuthController.java
+++ b/src/main/java/life/walkit/server/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package life.walkit.server.auth.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.Map;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class AuthController {
+
+    @GetMapping("/me")
+    public ResponseEntity<?> getCurrentUser(@AuthenticationPrincipal UserDetails member) {
+        if (member == null)
+            return ResponseEntity.ok(Map.of("status", "not logged in"));
+
+        return ResponseEntity.ok(Map.of("email logged in", member.getUsername()));
+    }
+}

--- a/src/main/java/life/walkit/server/auth/dto/CurrentUserDto.java
+++ b/src/main/java/life/walkit/server/auth/dto/CurrentUserDto.java
@@ -16,10 +16,7 @@ public class CurrentUserDto {
         return CurrentUserDto.builder()
                 .memberId(member.getMemberId())
                 .email(member.getEmail())
-                .isProfileSet(
-                        !(member.getName().isBlank() &&
-                                member.getNickname().equals(member.getEmail()))
-                )
+                .isProfileSet(!member.getEmail().equals(member.getNickname()))
                 .build();
     }
 }

--- a/src/main/java/life/walkit/server/auth/dto/CurrentUserDto.java
+++ b/src/main/java/life/walkit/server/auth/dto/CurrentUserDto.java
@@ -1,0 +1,25 @@
+package life.walkit.server.auth.dto;
+
+import life.walkit.server.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CurrentUserDto {
+
+    Long memberId;
+    String email;
+    Boolean isProfileSet;
+
+    public static CurrentUserDto of(Member member) {
+        return CurrentUserDto.builder()
+                .memberId(member.getMemberId())
+                .email(member.getEmail())
+                .isProfileSet(
+                        !(member.getName().isBlank() &&
+                                member.getNickname().equals(member.getEmail()))
+                )
+                .build();
+    }
+}

--- a/src/main/java/life/walkit/server/auth/dto/CustomMemberDetails.java
+++ b/src/main/java/life/walkit/server/auth/dto/CustomMemberDetails.java
@@ -1,0 +1,49 @@
+package life.walkit.server.auth.dto;
+
+import life.walkit.server.member.entity.Member;
+import life.walkit.server.member.entity.enums.MemberRole;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public record CustomMemberDetails(Member member) implements UserDetails {
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getEmail();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(MemberRole.USER.name()));
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+}

--- a/src/main/java/life/walkit/server/auth/dto/enums/AuthResponse.java
+++ b/src/main/java/life/walkit/server/auth/dto/enums/AuthResponse.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum AuthResponse implements Response {
+    LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공"),
     GET_CURRENT_MEMBER_SUCCESS(HttpStatus.OK, "본인확인 성공");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/life/walkit/server/auth/dto/enums/AuthResponse.java
+++ b/src/main/java/life/walkit/server/auth/dto/enums/AuthResponse.java
@@ -1,0 +1,23 @@
+package life.walkit.server.auth.dto.enums;
+
+import life.walkit.server.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum AuthResponse implements Response {
+    GET_CURRENT_MEMBER_SUCCESS(HttpStatus.OK, "본인확인 성공");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/life/walkit/server/auth/entity/JwtToken.java
+++ b/src/main/java/life/walkit/server/auth/entity/JwtToken.java
@@ -1,0 +1,22 @@
+package life.walkit.server.auth.entity;
+
+import life.walkit.server.auth.entity.enums.JwtTokenType;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+import java.time.Duration;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record JwtToken(
+        JwtTokenType type,
+        String value,
+        Duration duration
+) {
+    public static JwtToken of(JwtTokenType type, String value, Duration duration) {
+        return JwtToken.builder()
+                .type(type)
+                .value(value)
+                .duration(duration)
+                .build();
+    }
+}

--- a/src/main/java/life/walkit/server/auth/entity/enums/JwtTokenType.java
+++ b/src/main/java/life/walkit/server/auth/entity/enums/JwtTokenType.java
@@ -1,0 +1,16 @@
+package life.walkit.server.auth.entity.enums;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public enum JwtTokenType {
+
+    ACCESS_TOKEN("access-token"),
+    REFRESH_TOKEN("refresh-token");
+
+    private final String value;
+
+}

--- a/src/main/java/life/walkit/server/auth/error/JwtTokenException.java
+++ b/src/main/java/life/walkit/server/auth/error/JwtTokenException.java
@@ -1,0 +1,10 @@
+package life.walkit.server.auth.error;
+
+import life.walkit.server.global.error.core.BaseException;
+import life.walkit.server.global.error.core.ErrorCode;
+
+public class JwtTokenException extends BaseException {
+    public JwtTokenException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/life/walkit/server/auth/error/enums/JwtTokenErrorCode.java
+++ b/src/main/java/life/walkit/server/auth/error/enums/JwtTokenErrorCode.java
@@ -1,0 +1,28 @@
+package life.walkit.server.auth.error.enums;
+
+import life.walkit.server.global.error.core.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum JwtTokenErrorCode implements ErrorCode {
+
+    TOKEN_EXPIRED(HttpStatus.FORBIDDEN, "만료된 토큰입니다."),
+    TOKEN_UNTRUSTWORTHY(HttpStatus.FORBIDDEN, "신뢰할 수 없는 토큰입니다."),
+    TOKEN_ISSUE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 발급을 실패했습니다."),
+    TOKEN_SECRET_KEY_INVALID_LENGTH(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 시크릿 키의 길이가 유효하지 않습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return "[TOKEN ERROR] " + message;
+    }
+
+}

--- a/src/main/java/life/walkit/server/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/life/walkit/server/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,120 @@
+package life.walkit.server.auth.filter;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import life.walkit.server.auth.dto.CustomMemberDetails;
+import life.walkit.server.auth.jwt.JwtTokenParser;
+import life.walkit.server.member.entity.Member;
+import life.walkit.server.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenParser jwtTokenParser;
+    private final MemberRepository memberRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        try {
+            // 1. 쿠키에서 JWT 토큰 추출
+            String token = jwtTokenParser.resolveToken(request);
+
+            // 2. 토큰이 존재하고 유효한 경우에만 처리
+            if (token != null && !token.trim().isEmpty()) {
+
+                // 3. JWT 토큰 검증 및 Claims 파싱
+                Claims claims = jwtTokenParser.parseClaims(token);
+                String subject = claims.getSubject();
+                
+                // subject가 null이거나 빈 문자열인 경우 처리
+                if (subject == null || subject.trim().isEmpty()) {
+                    sendForbiddenResponse(response, "유효하지 않은 토큰입니다.");
+                    return;
+                }
+                
+                Long memberId = Long.parseLong(subject);
+                
+                // 4. memberId로 사용자 정보 조회
+                Member member = memberRepository.findById(memberId)
+                        .orElse(null);
+
+                // 5. 유효한 사용자인 경우 SecurityContextHolder에 인증 정보 설정
+                if (member != null) {
+                    CustomMemberDetails userDetails = new CustomMemberDetails(member);
+                    UsernamePasswordAuthenticationToken authentication = 
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    
+                    SecurityContextHolder.getContext().setAuthentication(authentication);
+                } else {
+                    // 사용자를 찾을 수 없는 경우 403 반환
+                    sendForbiddenResponse(response, "유효하지 않은 사용자입니다.");
+                    return;
+                }
+            } else {
+                log.info("Authorization 헤더에 JWT 토큰이 없습니다.");
+            }
+        } catch (ExpiredJwtException e) {
+            log.info("JWT 토큰이 만료되었습니다: {}", e.getMessage());
+            sendForbiddenResponse(response, "토큰이 만료되었습니다.");
+            return;
+        } catch (UnsupportedJwtException e) {
+            log.info("지원하지 않는 JWT 토큰입니다: {}", e.getMessage());
+            sendForbiddenResponse(response, "지원하지 않는 토큰 형식입니다.");
+            return;
+        } catch (MalformedJwtException e) {
+            log.info("잘못된 JWT 토큰 형식입니다: {}", e.getMessage());
+            sendForbiddenResponse(response, "잘못된 토큰 형식입니다.");
+            return;
+        } catch (SignatureException e) {
+            log.info("JWT 토큰 서명이 유효하지 않습니다: {}", e.getMessage());
+            sendForbiddenResponse(response, "토큰 서명이 유효하지 않습니다.");
+            return;
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 비어있습니다: {}", e.getMessage());
+            sendForbiddenResponse(response, "토큰이 비어있습니다.");
+            return;
+        } catch (Exception e) {
+            log.info("JWT 토큰 처리 중 예상치 못한 오류 발생: {}", e.getMessage());
+            sendForbiddenResponse(response, "토큰 처리 중 오류가 발생했습니다.");
+            return;
+        }
+        
+        // 6. 필터 체인 계속 진행
+        filterChain.doFilter(request, response);
+    }
+
+    private void sendForbiddenResponse(HttpServletResponse response, String message) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+        
+        // 애플리케이션의 BaseResponse 형식과 일치하는 JSON 응답
+        String jsonResponse = String.format("""
+            {
+              "httpStatus": 401,
+              "message": "%s",
+              "data": null
+            }
+            """, message);
+        
+        response.getWriter().write(jsonResponse);
+    }
+} 

--- a/src/main/java/life/walkit/server/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/life/walkit/server/auth/filter/JwtAuthenticationFilter.java
@@ -70,7 +70,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     return;
                 }
             } else {
-                log.info("Authorization 헤더에 JWT 토큰이 없습니다.");
+                log.debug("Authorization 헤더에 JWT 토큰이 없습니다.");
             }
         } catch (ExpiredJwtException e) {
             log.info("JWT 토큰이 만료되었습니다: {}", e.getMessage());

--- a/src/main/java/life/walkit/server/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/life/walkit/server/auth/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,87 @@
+package life.walkit.server.auth.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import life.walkit.server.auth.entity.JwtToken;
+import life.walkit.server.auth.jwt.JwtTokenIssuer;
+import life.walkit.server.auth.jwt.JwtTokenProperties;
+import life.walkit.server.global.util.CookieUtils;
+import life.walkit.server.member.entity.Member;
+import life.walkit.server.member.entity.enums.MemberRole;
+import life.walkit.server.member.entity.enums.MemberStatus;
+import life.walkit.server.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final MemberRepository memberRepository;
+    private final JwtTokenIssuer jwtTokenIssuer;
+    private final JwtTokenProperties jwtTokenProperties;
+
+    @Value("${app.oauth.login-redirect-url}")
+    String loginRedirectUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        String email = oAuth2User.getAttribute("email");
+        
+        // 회원가입 또는 기존 회원 조회
+        Member member = memberRepository.findByEmail(email)
+                .orElseGet(() -> {
+                    Member newMember = Member.builder()
+                            .email(email)
+                            .name("")
+                            .nickname(email)
+                            .status(MemberStatus.OFFLINE)
+                            .role(MemberRole.USER)
+                            .build();
+                    return memberRepository.save(newMember);
+                });
+
+        // JWT 토큰 발급
+        JwtToken accessToken = jwtTokenIssuer.issueAccessToken(member.getMemberId());
+        JwtToken refreshToken = jwtTokenIssuer.issueRefreshToken(member.getMemberId());
+
+        // 쿠키 설정
+        response.addHeader(
+                HttpHeaders.SET_COOKIE,
+                CookieUtils.create(
+                        accessToken.type().name(),
+                        accessToken.value(),
+                        accessToken.duration(),
+                        true,
+                        true,
+                        "None",
+                        jwtTokenProperties.domain()
+                ).toString()
+        );
+
+        response.addHeader(
+                HttpHeaders.SET_COOKIE,
+                CookieUtils.create(
+                        refreshToken.type().name(),
+                        refreshToken.value(),
+                        refreshToken.duration(),
+                        true,
+                        true,
+                        "None",
+                        jwtTokenProperties.domain()
+                ).toString()
+        );
+
+        response.sendRedirect(loginRedirectUrl);
+    }
+}

--- a/src/main/java/life/walkit/server/auth/jwt/JwtTokenIssuer.java
+++ b/src/main/java/life/walkit/server/auth/jwt/JwtTokenIssuer.java
@@ -1,0 +1,48 @@
+package life.walkit.server.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import life.walkit.server.auth.entity.JwtToken;
+import life.walkit.server.auth.entity.enums.JwtTokenType;
+import life.walkit.server.global.util.ClockUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenIssuer {
+
+    private final JwtTokenProperties jwtTokenProperties;
+
+    public JwtToken issueAccessToken(Long memberId) {
+        return JwtToken.of(
+                JwtTokenType.ACCESS_TOKEN,
+                issueToken(JwtTokenType.ACCESS_TOKEN, memberId, jwtTokenProperties.expiration().access()),
+                jwtTokenProperties.accessTokenDuration()
+        );
+    }
+
+    public JwtToken issueRefreshToken(Long memberId) {
+        return JwtToken.of(
+                JwtTokenType.REFRESH_TOKEN,
+                issueToken(JwtTokenType.REFRESH_TOKEN, memberId, jwtTokenProperties.expiration().refresh()),
+                jwtTokenProperties.refreshTokenDuration()
+        );
+    }
+
+    private String issueToken(JwtTokenType type, Long memberId, long expiration) {
+        LocalDateTime now = ClockUtils.getLocalDateTime();
+        return Jwts.builder()
+                .header()
+                .add("type", type)
+                .and()
+                .subject(String.valueOf(memberId))
+                .issuedAt(ClockUtils.convertToDate(now))
+                .expiration(ClockUtils.getExpirationDate(now, expiration))
+                .signWith(Keys.hmacShaKeyFor(jwtTokenProperties.secret().getBytes(StandardCharsets.UTF_8)))
+                .compact();
+    }
+}

--- a/src/main/java/life/walkit/server/auth/jwt/JwtTokenParser.java
+++ b/src/main/java/life/walkit/server/auth/jwt/JwtTokenParser.java
@@ -1,0 +1,58 @@
+package life.walkit.server.auth.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import life.walkit.server.auth.entity.enums.JwtTokenType;
+import life.walkit.server.auth.error.JwtTokenException;
+import life.walkit.server.auth.error.enums.JwtTokenErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenParser {
+
+    private final JwtTokenProperties jwtTokenProperties;
+
+    public Header parseHeader(String token) {
+        return getJwtParser()
+                .parseSignedClaims(token)
+                .getHeader();
+    }
+
+    public Claims parseClaims(String token) {
+        return getJwtParser()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    private JwtParser getJwtParser() {
+        return Jwts.parser()
+                .verifyWith(Keys.hmacShaKeyFor(jwtTokenProperties.secret().getBytes(StandardCharsets.UTF_8)))
+                .build();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        if (request.getCookies() == null) {
+            return null;
+        }
+
+        for (Cookie cookie : request.getCookies()) {
+            if (JwtTokenType.ACCESS_TOKEN.name().equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/life/walkit/server/auth/jwt/JwtTokenParser.java
+++ b/src/main/java/life/walkit/server/auth/jwt/JwtTokenParser.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import life.walkit.server.auth.entity.enums.JwtTokenType;
 import life.walkit.server.auth.error.JwtTokenException;
 import life.walkit.server.auth.error.enums.JwtTokenErrorCode;
+import life.walkit.server.global.util.CookieUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -42,17 +43,7 @@ public class JwtTokenParser {
     }
 
     public String resolveToken(HttpServletRequest request) {
-        if (request.getCookies() == null) {
-            return null;
-        }
-
-        for (Cookie cookie : request.getCookies()) {
-            if (JwtTokenType.ACCESS_TOKEN.name().equals(cookie.getName())) {
-                return cookie.getValue();
-            }
-        }
-
-        return null;
+        return CookieUtils.getCookieValue(request, JwtTokenType.ACCESS_TOKEN.name());
     }
 
 }

--- a/src/main/java/life/walkit/server/auth/jwt/JwtTokenProperties.java
+++ b/src/main/java/life/walkit/server/auth/jwt/JwtTokenProperties.java
@@ -1,0 +1,34 @@
+package life.walkit.server.auth.jwt;
+
+import jakarta.annotation.PostConstruct;
+import life.walkit.server.auth.error.JwtTokenException;
+import life.walkit.server.auth.error.enums.JwtTokenErrorCode;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtTokenProperties (
+        String secret,
+        Expiration expiration,
+        String domain
+) {
+
+    @PostConstruct
+    public void validate() {
+        if (secret == null || secret.getBytes(StandardCharsets.UTF_8).length < 32) {
+            throw new JwtTokenException(JwtTokenErrorCode.TOKEN_SECRET_KEY_INVALID_LENGTH);
+        }
+    }
+
+    public record Expiration(long access, long refresh) { }
+
+    public Duration accessTokenDuration() {
+        return Duration.ofSeconds(expiration.access());
+    }
+
+    public Duration refreshTokenDuration() {
+        return Duration.ofSeconds(expiration.refresh());
+    }
+}

--- a/src/main/java/life/walkit/server/auth/service/AuthService.java
+++ b/src/main/java/life/walkit/server/auth/service/AuthService.java
@@ -27,12 +27,17 @@ public class AuthService extends DefaultOAuth2UserService {
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        String registrationId = userRequest.getClientRegistration().getRegistrationId(); // "google", "kakao" 등
         OAuth2User user = super.loadUser(userRequest);
-        String email = user.getAttribute("email");
 
-        // 임시 사용자 정보 저장용
-        Map<String, Object> attributes = new HashMap<>(user.getAttributes());
-        attributes.put("email", email);
+        // 전달할 사용자 정보 저장
+        Map<String, Object> attributes = new HashMap<>();
+        if ("google".equals(registrationId)) {
+            attributes = getAttributesOfGoogleLogin(user);
+        }
+        else if ("kakao".equals(registrationId)) {
+            attributes = getAttributesOfKakaoLogin(user);
+        }
 
         return new DefaultOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority(MemberRole.USER.name())),
@@ -47,5 +52,30 @@ public class AuthService extends DefaultOAuth2UserService {
         );
 
         return CurrentUserDto.of(member);
+    }
+
+    private Map<String, Object> getAttributesOfGoogleLogin(OAuth2User user) {
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("email", user.getAttribute("email"));
+        attributes.put("name", user.getAttribute("name"));
+        attributes.put("profileImage", user.getAttribute("picture"));
+        return attributes;
+    }
+
+    private Map<String, Object> getAttributesOfKakaoLogin(OAuth2User user) {
+        Map<String, Object> attributes = new HashMap<>();
+
+        Map<String, Object> kakaoAccount = user.getAttribute("kakao_account");
+        String email = (String) kakaoAccount.get("email"); // 필수
+        attributes.put("email", email);
+
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        String name = profile != null ? (String) profile.get("nickname") : "";
+        String profileImage = profile != null ? (String) profile.get("profile_image_url") : "";
+
+        attributes.put("name", name != null ? name : "");
+        attributes.put("profileImage", profileImage != null ? profileImage : "");
+
+        return attributes;
     }
 }

--- a/src/main/java/life/walkit/server/auth/service/AuthService.java
+++ b/src/main/java/life/walkit/server/auth/service/AuthService.java
@@ -1,6 +1,10 @@
 package life.walkit.server.auth.service;
 
+import life.walkit.server.auth.dto.CurrentUserDto;
+import life.walkit.server.member.entity.Member;
 import life.walkit.server.member.entity.enums.MemberRole;
+import life.walkit.server.member.error.MemberException;
+import life.walkit.server.member.error.enums.MemberErrorCode;
 import life.walkit.server.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -35,5 +39,13 @@ public class AuthService extends DefaultOAuth2UserService {
                 attributes,
                 "email"
         );
+    }
+
+    public CurrentUserDto getCurrentUser(String email) {
+        Member member = memberRepository.findByEmail(email).orElseThrow(
+                () -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND)
+        );
+
+        return CurrentUserDto.of(member);
     }
 }

--- a/src/main/java/life/walkit/server/auth/service/AuthService.java
+++ b/src/main/java/life/walkit/server/auth/service/AuthService.java
@@ -1,0 +1,39 @@
+package life.walkit.server.auth.service;
+
+import life.walkit.server.member.entity.enums.MemberRole;
+import life.walkit.server.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService extends DefaultOAuth2UserService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User user = super.loadUser(userRequest);
+        String email = user.getAttribute("email");
+
+        // 임시 사용자 정보 저장용
+        Map<String, Object> attributes = new HashMap<>(user.getAttributes());
+        attributes.put("email", email);
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(MemberRole.USER.name())),
+                attributes,
+                "email"
+        );
+    }
+}

--- a/src/main/java/life/walkit/server/global/config/CorsConfig.java
+++ b/src/main/java/life/walkit/server/global/config/CorsConfig.java
@@ -1,0 +1,31 @@
+package life.walkit.server.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of(
+                "http://localhost:5173",
+                "http://localhost:5174",
+                "http://walkit.life",
+                "https://walkit.life"
+        ));
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
+}

--- a/src/main/java/life/walkit/server/global/config/SecurityConfig.java
+++ b/src/main/java/life/walkit/server/global/config/SecurityConfig.java
@@ -1,0 +1,60 @@
+package life.walkit.server.global.config;
+
+import life.walkit.server.auth.filter.JwtAuthenticationFilter;
+import life.walkit.server.auth.handler.OAuth2LoginSuccessHandler;
+import life.walkit.server.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    /**
+     * 인증 없이 접근 가능한 URL 패턴들
+     */
+    private static final String[] PERMIT_URL_ARRAY = {
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html",
+            "/api-docs/**",
+            "/actuator/health",
+            "/actuator/prometheus",
+            "/login/**"
+    };
+
+    private final AuthService authService;
+    private final OAuth2LoginSuccessHandler loginSuccessHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(Customizer.withDefaults())
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(
+                        session ->
+                                session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(PERMIT_URL_ARRAY).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth -> oauth
+                        .userInfoEndpoint(user -> user.userService(authService))
+                        .successHandler(loginSuccessHandler)
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/life/walkit/server/global/config/SecurityConfig.java
+++ b/src/main/java/life/walkit/server/global/config/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PERMIT_URL_ARRAY).permitAll()
-                        .anyRequest().authenticated()
+                        .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth -> oauth
                         .userInfoEndpoint(user -> user.userService(authService))

--- a/src/main/java/life/walkit/server/global/config/SecurityConfig.java
+++ b/src/main/java/life/walkit/server/global/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                 )
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PERMIT_URL_ARRAY).permitAll()
+                        .requestMatchers("/api/auth/**").authenticated()
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth -> oauth

--- a/src/main/java/life/walkit/server/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/life/walkit/server/global/error/handler/GlobalExceptionHandler.java
@@ -34,13 +34,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException e) {
-        log.error("RuntimeException 발생: {}", e.getMessage(), e);
+        log.debug("RuntimeException 발생: {}", e.getMessage(), e);
         return getErrorResponse(e, GlobalErrorCode.INTERNAL_SERVER_ERROR);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleException(Exception e) {
-        log.error("Exception 발생: {}", e.getMessage(), e);
+        log.debug("Exception 발생: {}", e.getMessage(), e);
         return getErrorResponse(e, GlobalErrorCode.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/life/walkit/server/global/util/ClockUtils.java
+++ b/src/main/java/life/walkit/server/global/util/ClockUtils.java
@@ -1,0 +1,37 @@
+package life.walkit.server.global.util;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ClockUtils {
+
+    private static final String TIMESTAMP_FORMAT = "yyyy-MM-dd HH:mm:ss";
+
+    private static class ClockInstanceHolder {
+        private static final Clock clock = Clock.systemDefaultZone();
+    }
+
+    public static LocalDateTime getLocalDateTime() {
+        return LocalDateTime.now(ClockInstanceHolder.clock);
+    }
+
+    public static String getLocalDateTimeToString() {
+        return getLocalDateTime().format(DateTimeFormatter.ofPattern(TIMESTAMP_FORMAT));
+    }
+
+    public static Date convertToDate(LocalDateTime now) {
+        return Date.from(now.atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    public static Date getExpirationDate(LocalDateTime now, long expirationTime) {
+        return Date.from(now.plusSeconds(expirationTime).atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+}

--- a/src/main/java/life/walkit/server/global/util/CookieUtils.java
+++ b/src/main/java/life/walkit/server/global/util/CookieUtils.java
@@ -1,0 +1,53 @@
+package life.walkit.server.global.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseCookie;
+
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+
+public class CookieUtils {
+
+    public static ResponseCookie create(String name, String value, Duration maxAge, boolean httpOnly, boolean secure, String sameSite, String domain) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, URLEncoder.encode(value, StandardCharsets.UTF_8))
+                .httpOnly(httpOnly)
+                .secure(secure)
+                .path("/")
+                .maxAge(maxAge)
+                .sameSite(sameSite);
+
+        if (domain != null && !domain.isEmpty()) {
+            builder.domain(domain);
+        }
+
+        return builder.build();
+    }
+
+    public static String getCookieValue(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return null;
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> name.equals(cookie.getName()))
+                .map(cookie -> URLDecoder.decode(cookie.getValue(), StandardCharsets.UTF_8))
+                .findFirst()
+                .orElse(null);
+    }
+
+    public static ResponseCookie deleteCookie(String name, boolean secure, String sameSite, String domain) {
+        ResponseCookie.ResponseCookieBuilder builder = ResponseCookie.from(name, "")
+                .path("/")
+                .httpOnly(true)
+                .secure(secure)
+                .maxAge(0)
+                .sameSite(sameSite);
+
+        if (domain != null && !domain.isEmpty()) {
+            builder.domain(domain);
+        }
+
+        return builder.build();
+    }
+
+}

--- a/src/main/java/life/walkit/server/member/service/MemberService.java
+++ b/src/main/java/life/walkit/server/member/service/MemberService.java
@@ -1,0 +1,30 @@
+package life.walkit.server.member.service;
+
+import life.walkit.server.member.entity.Member;
+import life.walkit.server.member.entity.enums.MemberRole;
+import life.walkit.server.member.entity.enums.MemberStatus;
+import life.walkit.server.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Member createMember(String email, String name, String profileImage) {
+        return memberRepository.findByEmail(email)
+                .orElseGet(() -> {
+                    Member newMember = Member.builder()
+                            .email(email)
+                            .name(name)
+                            .nickname(email)
+                            .status(MemberStatus.OFFLINE)
+                            .role(MemberRole.USER)
+                            .build();
+                    return memberRepository.save(newMember);
+                });
+    }
+
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#16 
closes #16

## 📝작업 내용

Spring Security 설정과 함께 Google, Kakao OAuth 회원가입 기능을 구현합니다.
토큰 재발급 기능은 구현되지 않았지만, 액세스 토큰 발급은 구현되었습니다.

- [x] Spring Security 설정
- [x] 회원가입 및 로그인 기능 구현 (이미 존재하는 회원이면 로그인으로 작동)
- [x] 토큰 발급 코드 작성
- [x] 본인확인 API 구현 

### 스크린샷 (선택)

<details>
    <summary>열기</summary>

<img width="971" height="192" alt="image" src="https://github.com/user-attachments/assets/95a21013-1229-4c23-8a20-007bc987560f" />
<img width="969" height="187" alt="image" src="https://github.com/user-attachments/assets/0ead9fc4-7db2-43da-a764-f7b253b48140" />


</details>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

스프링 시큐리티 관련된 내용이 한 PR로 설정 완료되어야 하다보니 추가된 코드 양이 많아졌습니다. 죄송합니다.

일단 스프링 시큐리티 관련해서 명시되지 않는 요청들은 `.anyRequest().permitAll()`로 설정해서 통과하도록 설정하였습니다.
추후 기본 값으로 로그인을 요구하고, 로그인하지 않아도 되는 API 들은 `PERMIT_URL_ARRAY` 배열에 모두 적을 예정이니,
로그인 없이 사용할 수 있는 기능이라면 `SecurityConfig` 파일에 `/api/walk/**` 이런 식으로 적어주세요!

