### PR TITLE
Feat/#27: 토큰 재발급 기능 추가

### DIFF
--- a/src/main/java/life/walkit/server/auth/controller/AuthController.java
+++ b/src/main/java/life/walkit/server/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import life.walkit.server.auth.dto.CurrentUserDto;
+import life.walkit.server.auth.dto.CustomMemberDetails;
 import life.walkit.server.auth.dto.enums.AuthResponse;
 import life.walkit.server.auth.entity.JwtToken;
 import life.walkit.server.auth.entity.enums.JwtTokenType;
@@ -43,7 +44,7 @@ public class AuthController {
 
     @Operation(summary = "로그아웃", description = "AccessToken 및 RefreshToken 쿠키를 삭제하여 로그아웃합니다.")
     @PostMapping("/logout")
-    public ResponseEntity<BaseResponse> logout(@AuthenticationPrincipal UserDetails member,
+    public ResponseEntity<BaseResponse> logout(@AuthenticationPrincipal CustomMemberDetails member,
                                                @RequestParam String deviceId, HttpServletResponse response) {
 
         // 액세스 토큰과 리프레시 토큰을 쿠키에서 제거
@@ -119,7 +120,7 @@ public class AuthController {
 
     @Operation(summary = "본인확인", description = "현재 로그인한 사용자의 정보를 조회합니다.")
     @GetMapping("/me")
-    public ResponseEntity<BaseResponse> getCurrentUser(@AuthenticationPrincipal UserDetails member) {
+    public ResponseEntity<BaseResponse> getCurrentUser(@AuthenticationPrincipal CustomMemberDetails member) {
         return BaseResponse.toResponseEntity(
                 AuthResponse.GET_CURRENT_MEMBER_SUCCESS,
                 authService.getCurrentUser(member.getUsername())

--- a/src/main/java/life/walkit/server/auth/controller/AuthController.java
+++ b/src/main/java/life/walkit/server/auth/controller/AuthController.java
@@ -107,6 +107,8 @@ public class AuthController {
                                 jwtTokenProperties.domain()
                         ).toString()
                 );
+            } else {
+                throw new JwtTokenException(JwtTokenErrorCode.REFRESH_TOKEN_INVALID);
             }
         } catch (Exception e) {
             throw new JwtTokenException(JwtTokenErrorCode.REFRESH_TOKEN_INVALID);

--- a/src/main/java/life/walkit/server/auth/controller/AuthController.java
+++ b/src/main/java/life/walkit/server/auth/controller/AuthController.java
@@ -69,6 +69,7 @@ public class AuthController {
         return BaseResponse.toResponseEntity(AuthResponse.LOGOUT_SUCCESS);
     }
 
+    @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰을 이용해 액세스 토큰을 재발급합니다.")
     @PostMapping("/reissue")
     public ResponseEntity<BaseResponse> reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
 

--- a/src/main/java/life/walkit/server/auth/dto/CustomMemberDetails.java
+++ b/src/main/java/life/walkit/server/auth/dto/CustomMemberDetails.java
@@ -1,7 +1,6 @@
 package life.walkit.server.auth.dto;
 
 import life.walkit.server.member.entity.Member;
-import life.walkit.server.member.entity.enums.MemberRole;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -10,6 +9,10 @@ import java.util.Collection;
 import java.util.List;
 
 public record CustomMemberDetails(Member member) implements UserDetails {
+
+    public Long getMemberId() {
+        return member.getMemberId();
+    }
 
     @Override
     public String getUsername() {

--- a/src/main/java/life/walkit/server/auth/dto/enums/AuthResponse.java
+++ b/src/main/java/life/walkit/server/auth/dto/enums/AuthResponse.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AuthResponse implements Response {
     LOGOUT_SUCCESS(HttpStatus.OK, "로그아웃 성공"),
+    ACCESS_TOKEN_REISSUE_SUCCESS(HttpStatus.OK, "액세스 토큰 재발급 성공"),
     GET_CURRENT_MEMBER_SUCCESS(HttpStatus.OK, "본인확인 성공");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/life/walkit/server/auth/error/enums/JwtTokenErrorCode.java
+++ b/src/main/java/life/walkit/server/auth/error/enums/JwtTokenErrorCode.java
@@ -11,7 +11,7 @@ public enum JwtTokenErrorCode implements ErrorCode {
     TOKEN_UNTRUSTWORTHY(HttpStatus.FORBIDDEN, "신뢰할 수 없는 토큰입니다."),
     TOKEN_ISSUE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 발급을 실패했습니다."),
     TOKEN_SECRET_KEY_INVALID_LENGTH(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 시크릿 키의 길이가 유효하지 않습니다."),
-    REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "리프레시 토큰이 없습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 없습니다."),
     REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/life/walkit/server/auth/error/enums/JwtTokenErrorCode.java
+++ b/src/main/java/life/walkit/server/auth/error/enums/JwtTokenErrorCode.java
@@ -10,7 +10,9 @@ public enum JwtTokenErrorCode implements ErrorCode {
     TOKEN_EXPIRED(HttpStatus.FORBIDDEN, "만료된 토큰입니다."),
     TOKEN_UNTRUSTWORTHY(HttpStatus.FORBIDDEN, "신뢰할 수 없는 토큰입니다."),
     TOKEN_ISSUE_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 발급을 실패했습니다."),
-    TOKEN_SECRET_KEY_INVALID_LENGTH(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 시크릿 키의 길이가 유효하지 않습니다.");
+    TOKEN_SECRET_KEY_INVALID_LENGTH(HttpStatus.INTERNAL_SERVER_ERROR, "토큰 시크릿 키의 길이가 유효하지 않습니다."),
+    REFRESH_TOKEN_NOT_FOUND(HttpStatus.BAD_REQUEST, "리프레시 토큰이 없습니다."),
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "리프레시 토큰이 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/life/walkit/server/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/life/walkit/server/auth/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,39 @@
+package life.walkit.server.auth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        if (response.isCommitted()) {
+            log.warn("Response is already committed. Cannot write error.");
+            return;
+        }
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        String jsonResponse = """
+            {
+              "httpStatus": 401,
+              "message": "인증이 필요합니다.",
+              "data": null
+            }
+        """;
+
+        response.getWriter().write(jsonResponse);
+    }
+}

--- a/src/main/java/life/walkit/server/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/life/walkit/server/auth/handler/OAuth2LoginSuccessHandler.java
@@ -42,6 +42,11 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
         try {
             // state 파라미터에서 deviceId 추출
             String deviceId = request.getParameter("state");
+            if (deviceId == null || deviceId.isBlank())
+                deviceId = "no-device-id";
+            // deviceId 길이 제한 (보안상 너무 긴 값 방지)
+            if (deviceId.length() > 50)
+                deviceId = deviceId.substring(0, 50);
 
             OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 

--- a/src/main/java/life/walkit/server/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/life/walkit/server/auth/handler/OAuth2LoginSuccessHandler.java
@@ -40,6 +40,9 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
         try {
+            // state 파라미터에서 deviceId 추출
+            String deviceId = request.getParameter("state");
+
             OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
 
             // 회원가입 또는 기존 회원 조회
@@ -51,7 +54,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
             // JWT 토큰 발급
             JwtToken accessToken = jwtTokenIssuer.issueAccessToken(member.getMemberId());
-            JwtToken refreshToken = jwtTokenIssuer.issueRefreshToken(member.getMemberId());
+            JwtToken refreshToken = jwtTokenIssuer.issueRefreshToken(member.getMemberId(), deviceId);
 
             // 쿠키 설정
             response.addHeader(

--- a/src/main/java/life/walkit/server/auth/jwt/JwtTokenIssuer.java
+++ b/src/main/java/life/walkit/server/auth/jwt/JwtTokenIssuer.java
@@ -27,9 +27,12 @@ public class JwtTokenIssuer {
         );
     }
 
-    public JwtToken issueRefreshToken(Long memberId) {
+    public JwtToken issueRefreshToken(Long memberId, String deviceId) {
         String refreshToken = issueToken(JwtTokenType.REFRESH_TOKEN, memberId, jwtTokenProperties.expiration().refresh());
-        jwtTokenRepository.saveWithTTL(memberId.toString(), refreshToken, jwtTokenProperties.refreshTokenDuration());
+
+        // Redis에 리프레시 토큰 저장
+        String key = memberId + ":" + deviceId;
+        jwtTokenRepository.saveWithTTL(key, refreshToken, jwtTokenProperties.refreshTokenDuration());
 
         return JwtToken.of(
                 JwtTokenType.REFRESH_TOKEN,

--- a/src/main/java/life/walkit/server/auth/jwt/JwtTokenIssuer.java
+++ b/src/main/java/life/walkit/server/auth/jwt/JwtTokenIssuer.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import life.walkit.server.auth.entity.JwtToken;
 import life.walkit.server.auth.entity.enums.JwtTokenType;
+import life.walkit.server.auth.repository.JwtTokenRepository;
 import life.walkit.server.global.util.ClockUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -16,6 +17,7 @@ import java.time.LocalDateTime;
 public class JwtTokenIssuer {
 
     private final JwtTokenProperties jwtTokenProperties;
+    private final JwtTokenRepository jwtTokenRepository;
 
     public JwtToken issueAccessToken(Long memberId) {
         return JwtToken.of(
@@ -26,9 +28,12 @@ public class JwtTokenIssuer {
     }
 
     public JwtToken issueRefreshToken(Long memberId) {
+        String refreshToken = issueToken(JwtTokenType.REFRESH_TOKEN, memberId, jwtTokenProperties.expiration().refresh());
+        jwtTokenRepository.saveWithTTL(memberId.toString(), refreshToken, jwtTokenProperties.refreshTokenDuration());
+
         return JwtToken.of(
                 JwtTokenType.REFRESH_TOKEN,
-                issueToken(JwtTokenType.REFRESH_TOKEN, memberId, jwtTokenProperties.expiration().refresh()),
+                refreshToken,
                 jwtTokenProperties.refreshTokenDuration()
         );
     }

--- a/src/main/java/life/walkit/server/auth/jwt/JwtTokenParser.java
+++ b/src/main/java/life/walkit/server/auth/jwt/JwtTokenParser.java
@@ -40,4 +40,8 @@ public class JwtTokenParser {
         return CookieUtils.getCookieValue(request, JwtTokenType.ACCESS_TOKEN.name());
     }
 
+    public String resolveRefreshToken(HttpServletRequest request) {
+        return CookieUtils.getCookieValue(request, JwtTokenType.REFRESH_TOKEN.name());
+    }
+
 }

--- a/src/main/java/life/walkit/server/auth/repository/JwtTokenRepository.java
+++ b/src/main/java/life/walkit/server/auth/repository/JwtTokenRepository.java
@@ -1,0 +1,31 @@
+package life.walkit.server.auth.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class JwtTokenRepository implements RedisKeyValueRepository<String, String>  {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    private final String PREFIX = "refreshToken:";
+
+    @Override
+    public void saveWithTTL(String key, String value, Duration duration) {
+        stringRedisTemplate.opsForValue().set(PREFIX + key, value, duration);
+    }
+
+    @Override
+    public Optional<String> findByKey(String key) {
+        return Optional.ofNullable(stringRedisTemplate.opsForValue().get(PREFIX + key));
+    }
+
+    @Override
+    public Boolean deleteByKey(String key) {
+        return stringRedisTemplate.delete(PREFIX + key);
+    }
+}

--- a/src/main/java/life/walkit/server/auth/repository/RedisKeyValueRepository.java
+++ b/src/main/java/life/walkit/server/auth/repository/RedisKeyValueRepository.java
@@ -1,0 +1,12 @@
+package life.walkit.server.auth.repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+public interface RedisKeyValueRepository<K, T> {
+
+    void saveWithTTL(K key, T value, Duration duration);
+    Optional<T> findByKey(K key);
+    Boolean deleteByKey(K key);
+
+}

--- a/src/main/java/life/walkit/server/auth/resolver/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/life/walkit/server/auth/resolver/CustomAuthorizationRequestResolver.java
@@ -31,11 +31,16 @@ public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRe
     private OAuth2AuthorizationRequest customize(OAuth2AuthorizationRequest req, HttpServletRequest request) {
         if (req == null) return null;
         String incomingState = request.getParameter("state");
-        if (incomingState != null) {
+        if (incomingState != null && isValidDeviceId(incomingState)) {
             return OAuth2AuthorizationRequest.from(req)
                     .state(incomingState)       // 내가 보낸 state 사용
                     .build();
         }
         return req;
+    }
+
+    private boolean isValidDeviceId(String deviceId) {
+        // deviceId 형식 검증 (알파벳, 숫자, 하이픈만 허용)
+        return deviceId.matches("^[a-zA-Z0-9-_]{1,50}$");
     }
 }

--- a/src/main/java/life/walkit/server/auth/resolver/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/life/walkit/server/auth/resolver/CustomAuthorizationRequestResolver.java
@@ -1,0 +1,41 @@
+package life.walkit.server.auth.resolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+/*
+ * 리프레시 토큰의 멀티디바이스 지원을 위해, deviceId를 OAuth 로그인시 state로 받기 위해 커스터마이징
+ */
+@Component
+public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+    private final OAuth2AuthorizationRequestResolver defaultResolver;
+
+    public CustomAuthorizationRequestResolver(ClientRegistrationRepository repo) {
+        this.defaultResolver = new DefaultOAuth2AuthorizationRequestResolver(repo, "/oauth2/authorization");
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        return customize(defaultResolver.resolve(request), request);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientId) {
+        return customize(defaultResolver.resolve(request, clientId), request);
+    }
+
+    private OAuth2AuthorizationRequest customize(OAuth2AuthorizationRequest req, HttpServletRequest request) {
+        if (req == null) return null;
+        String incomingState = request.getParameter("state");
+        if (incomingState != null) {
+            return OAuth2AuthorizationRequest.from(req)
+                    .state(incomingState)       // 내가 보낸 state 사용
+                    .build();
+        }
+        return req;
+    }
+}

--- a/src/main/java/life/walkit/server/global/config/SecurityConfig.java
+++ b/src/main/java/life/walkit/server/global/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package life.walkit.server.global.config;
 
 import life.walkit.server.auth.filter.JwtAuthenticationFilter;
+import life.walkit.server.auth.handler.CustomAuthenticationEntryPoint;
 import life.walkit.server.auth.handler.OAuth2LoginSuccessHandler;
 import life.walkit.server.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
@@ -25,15 +26,16 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html",
-            "/api-docs/**",
             "/actuator/health",
             "/actuator/prometheus",
+            "/api/auth/reissue",
             "/login/**"
     };
 
     private final AuthService authService;
     private final OAuth2LoginSuccessHandler loginSuccessHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -48,6 +50,9 @@ public class SecurityConfig {
                         .requestMatchers(PERMIT_URL_ARRAY).permitAll()
                         .requestMatchers("/api/auth/**").authenticated()
                         .anyRequest().permitAll() // TODO: 기본 인증 요구로 변경
+                )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(customAuthenticationEntryPoint) // 토큰 검증 실패시 401 응답
                 )
                 .oauth2Login(oauth -> oauth
                         .userInfoEndpoint(user -> user.userService(authService))

--- a/src/main/java/life/walkit/server/global/config/SecurityConfig.java
+++ b/src/main/java/life/walkit/server/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package life.walkit.server.global.config;
 import life.walkit.server.auth.filter.JwtAuthenticationFilter;
 import life.walkit.server.auth.handler.CustomAuthenticationEntryPoint;
 import life.walkit.server.auth.handler.OAuth2LoginSuccessHandler;
+import life.walkit.server.auth.resolver.CustomAuthorizationRequestResolver;
 import life.walkit.server.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -36,6 +37,7 @@ public class SecurityConfig {
     private final OAuth2LoginSuccessHandler loginSuccessHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAuthorizationRequestResolver customResolver;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -55,6 +57,10 @@ public class SecurityConfig {
                         .authenticationEntryPoint(customAuthenticationEntryPoint) // 토큰 검증 실패시 401 응답
                 )
                 .oauth2Login(oauth -> oauth
+                        .authorizationEndpoint(
+                                // state의 deviceId를 유지하도록 커스터마이징
+                                ep ->ep.authorizationRequestResolver(customResolver)
+                        )
                         .userInfoEndpoint(user -> user.userService(authService))
                         .successHandler(loginSuccessHandler)
                 )


### PR DESCRIPTION
## #️⃣연관된 이슈

#27 
closes #27

## 📝작업 내용

리프레시 토큰을 이용하여 액세스 토큰을 재발급하는 기능을 개발하였습니다.

- [x] 발급한 리프레시 토큰을 Redis에 저장
- [x] 리프레시 토큰 검증 후 액세스 토큰 재발급
- [x] 로그아웃시 리프레시 토큰을 Redis에서 삭제

### 스크린샷 (선택)

<details>
    <summary>열기</summary>

<img width="750" height="228" alt="image" src="https://github.com/user-attachments/assets/e9e54623-c372-4eca-b00b-424601ac5cb1" />

</details>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

로그인 및 본인확인 기능에 대한 프론트엔드 샘플 코드를 월요일에 제공하겠습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **신규 기능**
  * 리프레시 토큰을 이용한 액세스 토큰 재발급 엔드포인트(/reissue) 추가
  * 인증이 필요한 요청에 대해 커스텀 인증 예외 응답(401) 제공
  * OAuth2 로그인 시 deviceId 상태값 전달 및 처리 기능 추가
  * Redis 기반 JWT 리프레시 토큰 저장소 도입 및 관리 기능 추가
  * OAuth2 로그인 성공 시 deviceId 추출 및 토큰 발급에 반영
  * 커스텀 OAuth2 권한 요청 리졸버로 deviceId 상태값 검증 및 유지 기능 추가
  * 사용자 정보 조회 시 CustomMemberDetails 적용

* **버그 수정**
  * 로그아웃 시 Redis에 저장된 리프레시 토큰도 함께 삭제

* **개선 및 기타**
  * 리프레시 토큰 관련 에러 메시지 및 상태 코드 추가
  * 보안 설정에 토큰 재발급 엔드포인트 허용 및 인증 예외 처리 방식 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->