### PR TITLE
Feat/#42: 친구 요청 수신 목록 조회 기능 구현

### DIFF
--- a/src/main/java/life/walkit/server/friend/controller/FriendController.java
+++ b/src/main/java/life/walkit/server/friend/controller/FriendController.java
@@ -3,6 +3,7 @@ package life.walkit.server.friend.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import life.walkit.server.auth.dto.CustomMemberDetails;
 import life.walkit.server.friend.dto.FriendRequestResponseDTO;
+import life.walkit.server.friend.dto.ReceivedFriendResponse;
 import life.walkit.server.friend.dto.SentFriendResponse;
 import life.walkit.server.friend.enums.FriendRequestResponse;
 import life.walkit.server.friend.service.FriendService;
@@ -11,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -21,10 +23,7 @@ public class FriendController {
 
     private final FriendService friendService;
 
-    /**
-     * 친구 요청 보내기 (생성)
-     */
-    @Operation(summary = "친구 요청 보내기", description = "다른 사용자에게 친구 요청을 보냅니다.")
+    @Operation(summary = "친구 요청 생성", description = "다른 사용자에게 친구 요청을 보냅니다.")
     @PostMapping("/requests")
     public ResponseEntity<BaseResponse> sendFriendRequest(
             @AuthenticationPrincipal CustomMemberDetails member,
@@ -33,17 +32,21 @@ public class FriendController {
         return BaseResponse.toResponseEntity(FriendRequestResponse.REQUEST_SUCCESS, response);
     }
 
-    /**
-     * 내가 보낸 친구 요청 목록 조회
-     */
     @GetMapping("/requests/sent")
-    @Operation(summary = "보낸 친구 요청 목록 조회", description = "내가 보낸 친구 요청 목록을 조회합니다.")
+    @Operation(summary = "친구 요청 발신 목록 조회", description = "내가 보낸 친구 요청 목록을 조회합니다.")
     public ResponseEntity<BaseResponse> getSentFriendRequests(
             @AuthenticationPrincipal CustomMemberDetails member) {
         List<SentFriendResponse> responses = friendService.getSentFriendRequests(member.getMemberId());
         return BaseResponse.toResponseEntity(FriendRequestResponse.SENT_LIST_SUCCESS, responses);
     }
 
+    @GetMapping("/requests/received")
+    @Operation(summary = "친구 요청 수신 목록 조회", description = "내가 받은 친구 요청 목록을 조회합니다.")
+    public ResponseEntity<BaseResponse> getReceivedFriendRequests(
+            @AuthenticationPrincipal CustomMemberDetails member) {
+        List<ReceivedFriendResponse> responses = friendService.getReceivedFriendRequests(member.getMemberId());
+        return BaseResponse.toResponseEntity(FriendRequestResponse.RECEIVED_LIST_SUCCESS, responses);
+    }
 
 
 }

--- a/src/main/java/life/walkit/server/friend/dto/ReceivedFriendResponse.java
+++ b/src/main/java/life/walkit/server/friend/dto/ReceivedFriendResponse.java
@@ -1,0 +1,28 @@
+package life.walkit.server.friend.dto;
+
+import life.walkit.server.friend.enums.FriendRequestStatus;
+import life.walkit.server.member.entity.Member;
+import life.walkit.server.member.entity.ProfileImage;
+import java.util.Optional;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReceivedFriendResponse {
+
+    private String senderNickname;
+    private String profile;
+    private FriendRequestStatus requestStatus;
+
+    public static ReceivedFriendResponse of(Member sender, FriendRequestStatus requestStatus) {
+        return ReceivedFriendResponse.builder()
+                .senderNickname(sender.getNickname())
+                .profile(Optional.ofNullable(sender.getProfileImage())
+                        .map(ProfileImage::getProfileImage)
+                        .orElse(""))
+                .requestStatus(requestStatus)
+                .build();
+    }
+}
+

--- a/src/main/java/life/walkit/server/friend/service/FriendService.java
+++ b/src/main/java/life/walkit/server/friend/service/FriendService.java
@@ -1,8 +1,10 @@
 package life.walkit.server.friend.service;
 
-import jakarta.transaction.Transactional;
+import org.springframework.transaction.annotation.Transactional;
 import life.walkit.server.friend.dto.FriendRequestResponseDTO;
+import life.walkit.server.friend.dto.ReceivedFriendResponse;
 import life.walkit.server.friend.dto.SentFriendResponse;
+import life.walkit.server.friend.enums.FriendRequestStatus;
 import life.walkit.server.friend.error.FriendErrorCode;
 import life.walkit.server.friend.error.FriendException;
 import life.walkit.server.friend.repository.FriendRepository;
@@ -14,7 +16,6 @@ import life.walkit.server.member.error.enums.MemberErrorCode;
 import life.walkit.server.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
 import java.util.List;
 
 @Service
@@ -57,24 +58,35 @@ public class FriendService {
         );
     }
 
-    /**
-     * 내가 보낸 친구 요청 목록 조회
-     */
+    @Transactional(readOnly = true)
     public List<SentFriendResponse> getSentFriendRequests(Long memberId) {
         Member sender = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
-        // 'sender'로 보낸 친구 요청 목록을 조회
         List<FriendRequest> requests = friendRequestRepository.findBySender(sender);
 
-        // FriendRequest -> SentFriendResponse 매핑
         return requests.stream()
                 .map(request -> new SentFriendResponse(
-                        request.getReceiver().getNickname(), // 수신자의 닉네임
-                        request.getReceiver().getStatus()    // 수신자의 MemberStatus
+                        request.getReceiver().getNickname(),
+                        request.getReceiver().getStatus()
                 ))
-                .toList(); // 리스트로 변환하여 반환
+                .toList();
     }
+
+    @Transactional(readOnly = true)
+    public List<ReceivedFriendResponse> getReceivedFriendRequests(Long memberId) {
+        Member receiver = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        List<FriendRequest> requests = friendRequestRepository.findByReceiverAndStatus(receiver, FriendRequestStatus.PENDING);
+
+        return requests.stream()
+                .map(request -> ReceivedFriendResponse.of(request.getSender(), request.getStatus()))
+                .toList();
+    }
+
+
+
 
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#42 

## 📝작업 내용

- [x] 친구 요청 목록 조회 API 구현
- [x] ReceivedFriendResponse DTO 생성 및 적용
- [x] PENDING 상태의 친구 요청 필터링 후 응답 DTO로 매핑
- [x] 해당 기능 테스트 코드 작성


### 스크린샷 (선택)
<img width="561" height="54" alt="스크린샷 2025-07-29 오후 12 47 40" src="https://github.com/user-attachments/assets/ade532f4-2ab0-4130-a261-2957e4b68c98" />


</details>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 받은 친구 요청 목록을 조회할 수 있는 기능이 추가되었습니다.

* **문서**
  * 친구 요청 생성 및 발신 목록 조회 API의 설명 문구가 일부 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->