### PR TITLE
Feat/#50: 친구 요청 승인 기능 구현

### DIFF
--- a/src/main/java/life/walkit/server/friend/controller/FriendController.java
+++ b/src/main/java/life/walkit/server/friend/controller/FriendController.java
@@ -28,24 +28,28 @@ public class FriendController {
     public ResponseEntity<BaseResponse> sendFriendRequest(
             @AuthenticationPrincipal CustomMemberDetails member,
             @RequestParam String targetNickname) {
-        FriendRequestResponseDTO response = friendService.sendFriendRequest(member.getMemberId(), targetNickname);
-        return BaseResponse.toResponseEntity(FriendRequestResponse.REQUEST_SUCCESS, response);
+        return BaseResponse.toResponseEntity(FriendRequestResponse.REQUEST_SUCCESS, friendService.sendFriendRequest(member.getMemberId(), targetNickname));
     }
 
     @GetMapping("/requests/sent")
     @Operation(summary = "친구 요청 발신 목록 조회", description = "내가 보낸 친구 요청 목록을 조회합니다.")
     public ResponseEntity<BaseResponse> getSentFriendRequests(
             @AuthenticationPrincipal CustomMemberDetails member) {
-        List<SentFriendResponse> responses = friendService.getSentFriendRequests(member.getMemberId());
-        return BaseResponse.toResponseEntity(FriendRequestResponse.SENT_LIST_SUCCESS, responses);
+        return BaseResponse.toResponseEntity(FriendRequestResponse.SENT_LIST_SUCCESS, friendService.getSentFriendRequests(member.getMemberId()));
     }
 
     @GetMapping("/requests/received")
     @Operation(summary = "친구 요청 수신 목록 조회", description = "내가 받은 친구 요청 목록을 조회합니다.")
     public ResponseEntity<BaseResponse> getReceivedFriendRequests(
             @AuthenticationPrincipal CustomMemberDetails member) {
-        List<ReceivedFriendResponse> responses = friendService.getReceivedFriendRequests(member.getMemberId());
-        return BaseResponse.toResponseEntity(FriendRequestResponse.RECEIVED_LIST_SUCCESS, responses);
+        return BaseResponse.toResponseEntity(FriendRequestResponse.RECEIVED_LIST_SUCCESS, friendService.getReceivedFriendRequests(member.getMemberId()));
+    }
+
+    @PatchMapping("/requests/approve")
+    @Operation(summary = "친구 요청 승인", description = "친구 요청을 승인합니다.")
+    public ResponseEntity<BaseResponse> approveFriendRequest(@AuthenticationPrincipal CustomMemberDetails member, @RequestParam Long friendRequestId) {
+        friendService.approveFriendRequest(friendRequestId, member.getMemberId());
+        return BaseResponse.toResponseEntity(FriendRequestResponse.APPROVED_SUCCESS);
     }
 
 

--- a/src/main/java/life/walkit/server/friend/error/FriendErrorCode.java
+++ b/src/main/java/life/walkit/server/friend/error/FriendErrorCode.java
@@ -17,6 +17,7 @@ public enum FriendErrorCode implements ErrorCode {
     INVALID_REQUEST_STATUS(HttpStatus.BAD_REQUEST, "친구 요청 상태가 유효하지 않습니다."),
     FRIEND_REQUEST_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "상대방과의 친구 신청이 이미 존재합니다."),
     SELF_FRIEND_REQUEST(HttpStatus.BAD_REQUEST, "본인에게 친구 신청할 수 없습니다."),
+    UNAUTHORIZED_APPROVER(HttpStatus.FORBIDDEN, "해당 친구 요청을 승인할 권한이 없습니다."),
     FRIEND_STATUS_INVALID(HttpStatus.BAD_REQUEST, "친구 신청 승인 또는 거절시 상태가 잘못되었습니다.");
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈
#50 

## 📝작업 내용

- [ ] 친구 요청 수락 API 엔드포인트 구현
- [ ] 친구 요청 수락 서비스 로직 및 예외 처리 구현
- [ ] 승인 권한 없음 에러 코드 추가
- [ ] 친구 요청 승인 로직 테스트 코드 작성

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img width="389" height="50" alt="스크린샷 2025-07-29 오후 2 40 13" src="https://github.com/user-attachments/assets/54662869-a9db-4c9e-bbcf-789c6612d41f" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
