### PR TITLE
Chore/#54: SwaggerConfig 설정

### DIFF
--- a/src/main/java/life/walkit/server/auth/controller/AuthController.java
+++ b/src/main/java/life/walkit/server/auth/controller/AuthController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Arrays;
 
 @Tag(name = "인증", description = "인증 API")
+@SecurityRequirement(name = "cookieAuth")
 @Slf4j
 @RestController
 @RequiredArgsConstructor

--- a/src/main/java/life/walkit/server/auth/controller/AuthController.java
+++ b/src/main/java/life/walkit/server/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package life.walkit.server.auth.controller;
 
 import io.jsonwebtoken.Claims;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -24,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Arrays;
@@ -44,8 +44,10 @@ public class AuthController {
 
     @Operation(summary = "로그아웃", description = "AccessToken 및 RefreshToken 쿠키를 삭제하여 로그아웃합니다.")
     @PostMapping("/logout")
-    public ResponseEntity<BaseResponse> logout(@AuthenticationPrincipal CustomMemberDetails member,
-                                               @RequestParam String deviceId, HttpServletResponse response) {
+    public ResponseEntity<BaseResponse<Void>> logout(
+            @AuthenticationPrincipal CustomMemberDetails member,
+            @RequestParam String deviceId, HttpServletResponse response
+    ) {
 
         // 액세스 토큰과 리프레시 토큰을 쿠키에서 제거
         Arrays.stream(JwtTokenType.values()).forEach(tokenType ->
@@ -70,8 +72,10 @@ public class AuthController {
 
     @Operation(summary = "액세스 토큰 재발급", description = "리프레시 토큰을 이용해 액세스 토큰을 재발급합니다.")
     @PostMapping("/reissue")
-    public ResponseEntity<BaseResponse> reissueAccessToken(@RequestParam String deviceId,
-                                                           HttpServletRequest request, HttpServletResponse response) {
+    public ResponseEntity<BaseResponse<Void>> reissueAccessToken(
+            @RequestParam String deviceId,
+            HttpServletRequest request, HttpServletResponse response
+    ) {
 
         String refreshToken = jwtTokenParser.resolveRefreshToken(request);
         if (refreshToken == null || refreshToken.isBlank())
@@ -120,7 +124,9 @@ public class AuthController {
 
     @Operation(summary = "본인확인", description = "현재 로그인한 사용자의 정보를 조회합니다.")
     @GetMapping("/me")
-    public ResponseEntity<BaseResponse> getCurrentUser(@AuthenticationPrincipal CustomMemberDetails member) {
+    public ResponseEntity<BaseResponse<CurrentUserDto>> getCurrentUser(
+            @AuthenticationPrincipal CustomMemberDetails member
+    ) {
         return BaseResponse.toResponseEntity(
                 AuthResponse.GET_CURRENT_MEMBER_SUCCESS,
                 authService.getCurrentUser(member.getUsername())

--- a/src/main/java/life/walkit/server/auth/controller/OAuthSwaggerController.java
+++ b/src/main/java/life/walkit/server/auth/controller/OAuthSwaggerController.java
@@ -19,7 +19,7 @@ public class OAuthSwaggerController {
 
     @Operation(
             summary = "구글 로그인",
-            description = "구글 OAuth2 로그인을 위한 리디렉션 URL입니다. [실제 로그인 URL: `/oauth2/authorization/google?state=${deviceId}`] 브라우저에서 직접 접속하세요."
+            description = "구글 OAuth2 로그인을 위한 리디렉션 URL입니다. [실제 로그인 URL: `/oauth2/authorization/google?state={deviceId}`] 브라우저에서 직접 접속하세요."
     )
     @ApiResponse(responseCode = "302", description = "구글 로그인 페이지로 리디렉션")
     @GetMapping("/google-login")
@@ -30,7 +30,7 @@ public class OAuthSwaggerController {
 
     @Operation(
             summary = "카카오 로그인",
-            description = "카카오 OAuth2 로그인을 위한 리디렉션 URL입니다. [실제 로그인 URL: /oauth2/authorization/kakao?state=${deviceId}`] 브라우저에서 직접 접속하세요."
+            description = "카카오 OAuth2 로그인을 위한 리디렉션 URL입니다. [실제 로그인 URL: /oauth2/authorization/kakao?state={deviceId}`] 브라우저에서 직접 접속하세요."
     )
     @ApiResponse(responseCode = "302", description = "카카오 로그인 페이지로 리디렉션")
     @GetMapping("/kakao-login")

--- a/src/main/java/life/walkit/server/auth/controller/OAuthSwaggerController.java
+++ b/src/main/java/life/walkit/server/auth/controller/OAuthSwaggerController.java
@@ -19,7 +19,7 @@ public class OAuthSwaggerController {
 
     @Operation(
             summary = "구글 로그인",
-            description = "구글 OAuth2 로그인을 위한 리디렉션 URL입니다. [실제 로그인 URL: `/login/oauth2/code/google`] 브라우저에서 직접 접속하세요."
+            description = "구글 OAuth2 로그인을 위한 리디렉션 URL입니다. [실제 로그인 URL: `/oauth2/authorization/google?state=${deviceId}`] 브라우저에서 직접 접속하세요."
     )
     @ApiResponse(responseCode = "302", description = "구글 로그인 페이지로 리디렉션")
     @GetMapping("/google-login")
@@ -30,7 +30,7 @@ public class OAuthSwaggerController {
 
     @Operation(
             summary = "카카오 로그인",
-            description = "카카오 OAuth2 로그인을 위한 리디렉션 URL입니다. [실제 로그인 URL: `/login/oauth2/code/kakao`] 브라우저에서 직접 접속하세요."
+            description = "카카오 OAuth2 로그인을 위한 리디렉션 URL입니다. [실제 로그인 URL: /oauth2/authorization/kakao?state=${deviceId}`] 브라우저에서 직접 접속하세요."
     )
     @ApiResponse(responseCode = "302", description = "카카오 로그인 페이지로 리디렉션")
     @GetMapping("/kakao-login")

--- a/src/main/java/life/walkit/server/friend/controller/FriendController.java
+++ b/src/main/java/life/walkit/server/friend/controller/FriendController.java
@@ -1,6 +1,7 @@
 package life.walkit.server.friend.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import life.walkit.server.auth.dto.CustomMemberDetails;
 import life.walkit.server.friend.dto.FriendRequestResponseDTO;
@@ -18,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 @Tag(name = "친구", description = "친구 API")
+@SecurityRequirement(name = "cookieAuth")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/friends")

--- a/src/main/java/life/walkit/server/friend/controller/FriendController.java
+++ b/src/main/java/life/walkit/server/friend/controller/FriendController.java
@@ -1,6 +1,7 @@
 package life.walkit.server.friend.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import life.walkit.server.auth.dto.CustomMemberDetails;
 import life.walkit.server.friend.dto.FriendRequestResponseDTO;
 import life.walkit.server.friend.dto.ReceivedFriendResponse;
@@ -16,6 +17,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
+@Tag(name = "친구", description = "친구 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/friends")
@@ -25,25 +27,28 @@ public class FriendController {
 
     @Operation(summary = "친구 요청 생성", description = "다른 사용자에게 친구 요청을 보냅니다.")
     @PostMapping("/requests")
-    public ResponseEntity<BaseResponse> sendFriendRequest(
+    public ResponseEntity<BaseResponse<FriendRequestResponseDTO>> sendFriendRequest(
             @AuthenticationPrincipal CustomMemberDetails member,
-            @RequestParam String targetNickname) {
+            @RequestParam String targetNickname
+    ) {
         FriendRequestResponseDTO response = friendService.sendFriendRequest(member.getMemberId(), targetNickname);
         return BaseResponse.toResponseEntity(FriendRequestResponse.REQUEST_SUCCESS, response);
     }
 
     @GetMapping("/requests/sent")
     @Operation(summary = "친구 요청 발신 목록 조회", description = "내가 보낸 친구 요청 목록을 조회합니다.")
-    public ResponseEntity<BaseResponse> getSentFriendRequests(
-            @AuthenticationPrincipal CustomMemberDetails member) {
+    public ResponseEntity<BaseResponse<List<SentFriendResponse>>> getSentFriendRequests(
+            @AuthenticationPrincipal CustomMemberDetails member
+    ) {
         List<SentFriendResponse> responses = friendService.getSentFriendRequests(member.getMemberId());
         return BaseResponse.toResponseEntity(FriendRequestResponse.SENT_LIST_SUCCESS, responses);
     }
 
     @GetMapping("/requests/received")
     @Operation(summary = "친구 요청 수신 목록 조회", description = "내가 받은 친구 요청 목록을 조회합니다.")
-    public ResponseEntity<BaseResponse> getReceivedFriendRequests(
-            @AuthenticationPrincipal CustomMemberDetails member) {
+    public ResponseEntity<BaseResponse<List<ReceivedFriendResponse>>> getReceivedFriendRequests(
+            @AuthenticationPrincipal CustomMemberDetails member
+    ) {
         List<ReceivedFriendResponse> responses = friendService.getReceivedFriendRequests(member.getMemberId());
         return BaseResponse.toResponseEntity(FriendRequestResponse.RECEIVED_LIST_SUCCESS, responses);
     }

--- a/src/main/java/life/walkit/server/friend/controller/FriendController.java
+++ b/src/main/java/life/walkit/server/friend/controller/FriendController.java
@@ -33,7 +33,6 @@ public class FriendController {
             @AuthenticationPrincipal CustomMemberDetails member,
             @RequestParam String targetNickname
     ) {
-        FriendRequestResponseDTO response = friendService.sendFriendRequest(member.getMemberId(), targetNickname);
         return BaseResponse.toResponseEntity(
                 FriendRequestResponse.REQUEST_SUCCESS,
                 friendService.sendFriendRequest(member.getMemberId(), targetNickname)

--- a/src/main/java/life/walkit/server/global/config/SwaggerConfig.java
+++ b/src/main/java/life/walkit/server/global/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package life.walkit.server.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("cookieAuth",
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.COOKIE)
+                                        .name("ACCESS_TOKEN") // 쿠키 이름
+                        )
+                )
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("Walkit API")
+                .description("소셜 위치 기반 산책 플랫폼 Walkit의 API 명세서입니다.")
+                .version("v1.0.0")
+                .contact(new Contact()
+                        .name("Walkit Team")
+                        .url("https://walkit.life"));
+    }
+
+
+}

--- a/src/main/java/life/walkit/server/global/response/BaseResponse.java
+++ b/src/main/java/life/walkit/server/global/response/BaseResponse.java
@@ -7,40 +7,40 @@ import org.springframework.http.ResponseEntity;
 
 @Getter
 @Builder
-public class BaseResponse {
+public class BaseResponse<T> {
 
     private final Integer httpStatus;
     private final String message;
-    private final Object data;
+    private final T data;
 
-    public static ResponseEntity<BaseResponse> toResponseEntity(Response response) {
+    public static ResponseEntity<BaseResponse<Void>> toResponseEntity(Response response) {
         return ResponseEntity.status(response.getHttpStatus())
-                .body(BaseResponse.builder()
+                .body(BaseResponse.<Void>builder()
                         .httpStatus(response.getHttpStatus().value())
                         .message(response.getMessage())
                         .build());
     }
 
-    public static ResponseEntity<BaseResponse> toResponseEntity(HttpStatus httpStatus, String message) {
+    public static <T> ResponseEntity<BaseResponse<Void>> toResponseEntity(HttpStatus httpStatus, String message) {
        return ResponseEntity.status(httpStatus)
-                .body(BaseResponse.builder()
+                .body(BaseResponse.<Void>builder()
                         .httpStatus(httpStatus.value())
                         .message(message)
                         .build());
     }
 
-    public static ResponseEntity<BaseResponse> toResponseEntity(Response response, Object data) {
+    public static <T> ResponseEntity<BaseResponse<T>> toResponseEntity(Response response, T data) {
         return ResponseEntity.status(response.getHttpStatus())
-                .body(BaseResponse.builder()
+                .body(BaseResponse.<T>builder()
                         .httpStatus(response.getHttpStatus().value())
                         .message(response.getMessage())
                         .data(data)
                         .build());
     }
 
-    public static ResponseEntity<BaseResponse> toResponseEntity(HttpStatus httpStatus, String message, Object data) {
+    public static <T> ResponseEntity<BaseResponse<T>> toResponseEntity(HttpStatus httpStatus, String message, T data) {
         return ResponseEntity.status(httpStatus)
-                .body(BaseResponse.builder()
+                .body(BaseResponse.<T>builder()
                         .httpStatus(httpStatus.value())
                         .message(message)
                         .data(data)

--- a/src/main/java/life/walkit/server/member/controller/MemberController.java
+++ b/src/main/java/life/walkit/server/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import life.walkit.server.auth.dto.CustomMemberDetails;
 import life.walkit.server.global.response.BaseResponse;
 import life.walkit.server.member.dto.LocationDto;
 import life.walkit.server.member.dto.ProfileRequest;
+import life.walkit.server.member.dto.ProfileResponse;
 import life.walkit.server.member.dto.enums.MemberResponse;
 import life.walkit.server.member.error.MemberException;
 import life.walkit.server.member.error.enums.MemberErrorCode;
@@ -27,8 +28,10 @@ public class MemberController {
 
     @Operation(summary = "내 정보 조회", description = "이름과 닉네임, 프로필 이미지, 이메일을 조회합니다.")
     @GetMapping("/{memberId}")
-    public ResponseEntity<BaseResponse> getProfile(@PathVariable("memberId") Long memberId,
-                                                   @AuthenticationPrincipal CustomMemberDetails member) {
+    public ResponseEntity<BaseResponse<ProfileResponse>> getProfile(
+            @PathVariable("memberId") Long memberId,
+            @AuthenticationPrincipal CustomMemberDetails member
+    ) {
 
         if (!memberId.equals(member.getMemberId())) {
             throw new MemberException(MemberErrorCode.MEMBER_FORBIDDEN);
@@ -42,10 +45,12 @@ public class MemberController {
 
     @Operation(summary = "프로필 수정", description = "이름과 닉네임, 프로필 이미지를 수정합니다.")
     @PutMapping("/{memberId}")
-    public ResponseEntity<BaseResponse> updateProfile(@PathVariable Long memberId,
-                                                      @AuthenticationPrincipal CustomMemberDetails member,
-                                                      @Valid @RequestPart("data") ProfileRequest request,
-                                                      @RequestPart("profileImage") MultipartFile profileImage) {
+    public ResponseEntity<BaseResponse<ProfileResponse>> updateProfile(
+            @PathVariable Long memberId,
+            @AuthenticationPrincipal CustomMemberDetails member,
+            @Valid @RequestPart("data") ProfileRequest request,
+            @RequestPart("profileImage") MultipartFile profileImage
+    ) {
 
         if (!memberId.equals(member.getMemberId())) {
             throw new MemberException(MemberErrorCode.MEMBER_FORBIDDEN);
@@ -59,9 +64,11 @@ public class MemberController {
 
     @Operation(summary = "현재 위치 갱신", description = "자신의 현재 위치를 갱신합니다.")
     @PutMapping("/{memberId}/location")
-    public ResponseEntity<BaseResponse> updateLocation(@PathVariable Long memberId,
-                                                      @AuthenticationPrincipal CustomMemberDetails member,
-                                                      @Valid @RequestBody LocationDto location) {
+    public ResponseEntity<BaseResponse<LocationDto>> updateLocation(
+            @PathVariable Long memberId,
+            @AuthenticationPrincipal CustomMemberDetails member,
+            @Valid @RequestBody LocationDto location
+    ) {
 
         if (!memberId.equals(member.getMemberId())) {
             throw new MemberException(MemberErrorCode.MEMBER_FORBIDDEN);

--- a/src/main/java/life/walkit/server/member/controller/MemberController.java
+++ b/src/main/java/life/walkit/server/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package life.walkit.server.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import life.walkit.server.auth.dto.CustomMemberDetails;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "회원", description = "회원 API")
+@SecurityRequirement(name = "cookieAuth")
 @RequestMapping("/api/members")
 @RestController
 @RequiredArgsConstructor


### PR DESCRIPTION
## #️⃣연관된 이슈

#54
closes #54

## 📝작업 내용

`SwaggerConfig`와 관련된 설정을 정비합니다.

- 응답 DTO의 필드가 Swagger 문서에 표시되도록 합니다.
- SwaggerConfig 파일을 생성합니다.
- JWT 토큰이 필요한 응답을 명시합니다.
- Swagger 문서에서 토큰 쿠키를 함께 보내 테스트할 수 있도록 합니다.

### 스크린샷 (선택)

<details>
    <summary>열기</summary>

<img width="1416" height="830" alt="image" src="https://github.com/user-attachments/assets/342a01fc-4136-4896-8023-5b8b109eaed5" />

</details>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
