### PR TITLE
Refactor/#56: Swagger 문서 관련 multipart/form-data 명시

### DIFF
--- a/src/main/java/life/walkit/server/member/controller/MemberController.java
+++ b/src/main/java/life/walkit/server/member/controller/MemberController.java
@@ -47,7 +47,7 @@ public class MemberController {
     }
 
     @Operation(summary = "프로필 수정", description = "이름과 닉네임, 프로필 이미지를 수정합니다.")
-    @PutMapping(name = "/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PutMapping(value = "/{memberId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<BaseResponse<ProfileResponse>> updateProfile(
             @PathVariable Long memberId,
             @AuthenticationPrincipal CustomMemberDetails member,


### PR DESCRIPTION
## #️⃣연관된 이슈

#56 
closes #56

## 📝작업 내용

프로필 수정에 `consume=multipart/form-data` 명시. Swagger 문서에 정상적으로 표시하기 위함.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 프로필 업데이트 기능에서 multipart/form-data 형식의 요청을 명확하게 지원하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->