### PR TITLE
Feat/#51: 친구 요청 거절 기능 구현

### DIFF
--- a/src/main/java/life/walkit/server/friend/controller/FriendController.java
+++ b/src/main/java/life/walkit/server/friend/controller/FriendController.java
@@ -71,4 +71,14 @@ public class FriendController {
         return BaseResponse.toResponseEntity(FriendRequestResponse.APPROVED_SUCCESS);
     }
 
+    @DeleteMapping("/requests/{friendRequestId}")
+    @Operation(summary = "친구 요청 거절", description = "친구 요청을 거절합니다.")
+    public ResponseEntity<BaseResponse<Void>> rejectFriendRequest(
+            @AuthenticationPrincipal CustomMemberDetails member,
+            @PathVariable Long friendRequestId
+    ) {
+        friendService.rejectFriendRequest(friendRequestId, member.getMemberId());
+        return BaseResponse.toResponseEntity(FriendRequestResponse.REJECTED_SUCCESS);
+    }
+
 }

--- a/src/main/java/life/walkit/server/friend/service/FriendService.java
+++ b/src/main/java/life/walkit/server/friend/service/FriendService.java
@@ -86,7 +86,7 @@ public class FriendService {
                 .toList();
     }
 
-    public void approveFriendRequest(Long friendRequestId, Long approverId) {
+    public void approveFriendRequest(Long friendRequestId, Long memberId) {
         FriendRequest friendRequest = friendRequestRepository.findById(friendRequestId)
                 .orElseThrow(() -> new FriendException(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
 
@@ -94,7 +94,7 @@ public class FriendService {
             throw new FriendException(FriendErrorCode.FRIEND_STATUS_INVALID);
         }
 
-        if (!friendRequest.getReceiver().getMemberId().equals(approverId)) {
+        if (!friendRequest.getReceiver().getMemberId().equals(memberId)) {
             throw new FriendException(FriendErrorCode.UNAUTHORIZED_APPROVER);
         }
 
@@ -115,7 +115,21 @@ public class FriendService {
         friendRepository.saveAll(friends);
     }
 
+    public void rejectFriendRequest(Long friendRequestId, Long memberId) {
 
+        FriendRequest request = friendRequestRepository.findById(friendRequestId)
+                .orElseThrow(() -> new FriendException(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
+
+        if (!request.getStatus().equals(FriendRequestStatus.PENDING)) {
+            throw new FriendException(FriendErrorCode.FRIEND_STATUS_INVALID);
+        }
+
+        if (!request.getReceiver().getMemberId().equals(memberId)) {
+            throw new FriendException(FriendErrorCode.UNAUTHORIZED_APPROVER);
+        }
+
+        friendRequestRepository.delete(request);
+    }
 }
 
 

--- a/src/test/java/life/walkit/server/friend/service/FriendServiceTest.java
+++ b/src/test/java/life/walkit/server/friend/service/FriendServiceTest.java
@@ -168,6 +168,28 @@ public class FriendServiceTest {
                 .hasMessage(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND.getMessage());
     }
 
+    @Test
+    @DisplayName("친구 요청 거절 실패 - 거절자가 요청의 수신자가 아님")
+    void rejectFriendRequest_fail_unauthorizedRejecter() {
+        FriendRequest friendRequest = friendRequestRepository.save(createFriendRequest(memberB, memberA));
+
+        assertThatThrownBy(() -> friendService.rejectFriendRequest(friendRequest.getFriendRequestId(), memberB.getMemberId()))
+                .isInstanceOf(FriendException.class)
+                .hasMessage(FriendErrorCode.UNAUTHORIZED_APPROVER.getMessage());
+    }
+
+    @Test
+    @DisplayName("친구 요청 거절 실패 - 이미 승인된 요청")
+    void rejectFriendRequest_fail_alreadyApproved() {
+        FriendRequest friendRequest = friendRequestRepository.save(createFriendRequest(memberB, memberA));
+        friendRequest.approve();
+        friendRequestRepository.save(friendRequest);
+
+        assertThatThrownBy(() -> friendService.rejectFriendRequest(friendRequest.getFriendRequestId(), memberA.getMemberId()))
+                .isInstanceOf(FriendException.class)
+                .hasMessage(FriendErrorCode.FRIEND_STATUS_INVALID.getMessage());
+    }
+
 
 
 

--- a/src/test/java/life/walkit/server/friend/service/FriendServiceTest.java
+++ b/src/test/java/life/walkit/server/friend/service/FriendServiceTest.java
@@ -147,6 +147,28 @@ public class FriendServiceTest {
                 .hasMessage(FriendErrorCode.UNAUTHORIZED_APPROVER.getMessage());
     }
 
+    @Test
+    @Transactional
+    @DisplayName("친구 요청 거절 성공")
+    void rejectFriendRequest_success() {
+        FriendRequest friendRequest = friendRequestRepository.save(createFriendRequest(memberB, memberA)); // B -> A
+
+        friendService.rejectFriendRequest(friendRequest.getFriendRequestId(), memberA.getMemberId());
+
+        assertThat(friendRequestRepository.findById(friendRequest.getFriendRequestId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("친구 요청 거절 실패 - 요청이 존재하지 않음")
+    void rejectFriendRequest_fail_requestNotFound() {
+        Long invalidRequestId = 999L;
+
+        assertThatThrownBy(() -> friendService.rejectFriendRequest(invalidRequestId, memberA.getMemberId()))
+                .isInstanceOf(FriendException.class)
+                .hasMessage(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND.getMessage());
+    }
+
+
 
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#51 

## 📝작업 내용
- [ ] 친구 요청 거절 API 엔드포인트 추가
- [ ] 친구 요청 거절 비즈니스 로직 구현 (요청 거절 시 친구 요청 내역 삭제 처리)
- [ ] 친구 요청 거절 로직 테스트 코드 작성

### 스크린샷 (선택)
<img width="432" height="54" alt="스크린샷 2025-07-30 오전 9 51 56" src="https://github.com/user-attachments/assets/6fec4633-a447-4f4e-b475-f8ce6361e5e9" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 친구 요청 거절 기능이 추가되었습니다. 이제 받은 친구 요청을 거절할 수 있습니다.

* **테스트**
  * 친구 요청 거절 성공 및 실패 시나리오에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->