### PR TITLE
Feat/#59: 친구 목록 조회 기능 구현

### DIFF
--- a/src/main/java/life/walkit/server/friend/controller/FriendController.java
+++ b/src/main/java/life/walkit/server/friend/controller/FriendController.java
@@ -4,10 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import life.walkit.server.auth.dto.CustomMemberDetails;
-import life.walkit.server.friend.dto.FriendRequestResponseDTO;
-import life.walkit.server.friend.dto.FriendResponseDTO;
-import life.walkit.server.friend.dto.ReceivedFriendResponse;
-import life.walkit.server.friend.dto.SentFriendResponse;
+import life.walkit.server.friend.dto.*;
 import life.walkit.server.friend.enums.FriendRequestResponse;
 import life.walkit.server.friend.enums.FriendResponse;
 import life.walkit.server.friend.service.FriendService;
@@ -61,14 +58,15 @@ public class FriendController {
         );
     }
 
-    @PatchMapping("/request/{friendRequestId}")
+    @PutMapping("/request/{friendRequestId}")
     @Operation(summary = "친구 요청 승인", description = "친구 요청을 승인합니다.")
-    public ResponseEntity<BaseResponse<Void>> approveFriendRequest(
+    public ResponseEntity<BaseResponse<FriendRequestApprovedResponse>> approveFriendRequest(
             @AuthenticationPrincipal CustomMemberDetails member,
             @PathVariable Long friendRequestId
     ) {
-        friendService.approveFriendRequest(friendRequestId, member.getMemberId());
-        return BaseResponse.toResponseEntity(FriendRequestResponse.APPROVED_SUCCESS);
+        return BaseResponse.toResponseEntity(
+                FriendRequestResponse.APPROVED_SUCCESS,
+                friendService.approveFriendRequest(friendRequestId, member.getMemberId()));
     }
 
     @DeleteMapping("/request/{friendRequestId}")
@@ -92,3 +90,5 @@ public class FriendController {
     }
 
 }
+
+

--- a/src/main/java/life/walkit/server/friend/controller/FriendController.java
+++ b/src/main/java/life/walkit/server/friend/controller/FriendController.java
@@ -71,7 +71,7 @@ public class FriendController {
         return BaseResponse.toResponseEntity(FriendRequestResponse.APPROVED_SUCCESS);
     }
 
-    @DeleteMapping("/requests/{friendRequestId}")
+    @DeleteMapping("/request/{friendRequestId}")
     @Operation(summary = "친구 요청 거절", description = "친구 요청을 거절합니다.")
     public ResponseEntity<BaseResponse<Void>> rejectFriendRequest(
             @AuthenticationPrincipal CustomMemberDetails member,

--- a/src/main/java/life/walkit/server/friend/controller/FriendController.java
+++ b/src/main/java/life/walkit/server/friend/controller/FriendController.java
@@ -16,8 +16,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.util.List;
 
 @Tag(name = "친구", description = "친구 API")

--- a/src/main/java/life/walkit/server/friend/controller/FriendController.java
+++ b/src/main/java/life/walkit/server/friend/controller/FriendController.java
@@ -5,17 +5,17 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import life.walkit.server.auth.dto.CustomMemberDetails;
 import life.walkit.server.friend.dto.FriendRequestResponseDTO;
+import life.walkit.server.friend.dto.FriendResponseDTO;
 import life.walkit.server.friend.dto.ReceivedFriendResponse;
 import life.walkit.server.friend.dto.SentFriendResponse;
 import life.walkit.server.friend.enums.FriendRequestResponse;
+import life.walkit.server.friend.enums.FriendResponse;
 import life.walkit.server.friend.service.FriendService;
 import life.walkit.server.global.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
 import java.util.List;
 
 @Tag(name = "친구", description = "친구 API")
@@ -28,7 +28,7 @@ public class FriendController {
     private final FriendService friendService;
 
     @Operation(summary = "친구 요청 생성", description = "다른 사용자에게 친구 요청을 보냅니다.")
-    @PostMapping("/requests")
+    @PostMapping("/request")
     public ResponseEntity<BaseResponse<FriendRequestResponseDTO>> sendFriendRequest(
             @AuthenticationPrincipal CustomMemberDetails member,
             @RequestParam String targetNickname
@@ -39,7 +39,7 @@ public class FriendController {
         );
     }
 
-    @GetMapping("/requests/sent")
+    @GetMapping("/request/sent")
     @Operation(summary = "친구 요청 발신 목록 조회", description = "내가 보낸 친구 요청 목록을 조회합니다.")
     public ResponseEntity<BaseResponse<List<SentFriendResponse>>> getSentFriendRequests(
             @AuthenticationPrincipal CustomMemberDetails member
@@ -50,7 +50,7 @@ public class FriendController {
         );
     }
 
-    @GetMapping("/requests/received")
+    @GetMapping("/request/received")
     @Operation(summary = "친구 요청 수신 목록 조회", description = "내가 받은 친구 요청 목록을 조회합니다.")
     public ResponseEntity<BaseResponse<List<ReceivedFriendResponse>>> getReceivedFriendRequests(
             @AuthenticationPrincipal CustomMemberDetails member
@@ -61,14 +61,24 @@ public class FriendController {
         );
     }
 
-    @PatchMapping("/requests/approve")
+    @PatchMapping("/request/{friendRequestId}")
     @Operation(summary = "친구 요청 승인", description = "친구 요청을 승인합니다.")
     public ResponseEntity<BaseResponse<Void>> approveFriendRequest(
             @AuthenticationPrincipal CustomMemberDetails member,
-            @RequestParam Long friendRequestId
+            @PathVariable Long friendRequestId
     ) {
         friendService.approveFriendRequest(friendRequestId, member.getMemberId());
         return BaseResponse.toResponseEntity(FriendRequestResponse.APPROVED_SUCCESS);
+    }
+
+    @GetMapping
+    @Operation(summary = "친구 목록 조회", description = "현재 사용자의 친구 목록을 조회합니다.")
+    public ResponseEntity<BaseResponse<List<FriendResponseDTO>>> getFriends(
+            @AuthenticationPrincipal CustomMemberDetails member
+    ) {
+        return BaseResponse.toResponseEntity(
+                FriendResponse.LIST_SUCCESS,
+                friendService.getFriends(member.getMemberId()));
     }
 
 }

--- a/src/main/java/life/walkit/server/friend/dto/FriendRequestApprovedResponse.java
+++ b/src/main/java/life/walkit/server/friend/dto/FriendRequestApprovedResponse.java
@@ -1,0 +1,10 @@
+package life.walkit.server.friend.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FriendRequestApprovedResponse {
+    private Long friendId; // 승인된 친구 ID
+}

--- a/src/main/java/life/walkit/server/friend/dto/FriendResponseDTO.java
+++ b/src/main/java/life/walkit/server/friend/dto/FriendResponseDTO.java
@@ -1,0 +1,32 @@
+package life.walkit.server.friend.dto;
+
+import life.walkit.server.member.dto.LocationDto;
+import life.walkit.server.member.entity.Member;
+import life.walkit.server.member.entity.ProfileImage;
+import life.walkit.server.member.entity.enums.MemberStatus;
+import java.util.Optional;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FriendResponseDTO {
+    private Long friendId;
+    private String nickname;
+    private String profile;
+    private MemberStatus memberStatus;
+    private LocationDto lastLocation;
+
+    public static FriendResponseDTO of(Member member, LocationDto lastLocation) {
+        return FriendResponseDTO.builder()
+                .friendId(member.getMemberId())
+                .nickname(member.getNickname())
+                .profile(Optional.ofNullable(member.getProfileImage())
+                        .map(ProfileImage::getProfileImage)
+                        .orElse(""))
+                .memberStatus(member.getStatus())
+                .lastLocation(lastLocation)
+                .build();
+    }
+}
+

--- a/src/main/java/life/walkit/server/friend/service/FriendService.java
+++ b/src/main/java/life/walkit/server/friend/service/FriendService.java
@@ -1,6 +1,8 @@
 package life.walkit.server.friend.service;
 
+import life.walkit.server.friend.dto.FriendResponseDTO;
 import life.walkit.server.friend.entity.Friend;
+import life.walkit.server.member.dto.LocationDto;
 import org.springframework.transaction.annotation.Transactional;
 import life.walkit.server.friend.dto.FriendRequestResponseDTO;
 import life.walkit.server.friend.dto.ReceivedFriendResponse;
@@ -114,6 +116,36 @@ public class FriendService {
 
         friendRepository.saveAll(friends);
     }
+
+    @Transactional(readOnly = true)
+    public List<FriendResponseDTO> getFriends(Long memberId) {
+        // 주어진 memberId로 회원(Member) 정보 조회, 존재하지 않을 경우 예외 발생
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        // 회원과 연관된 친구 관계를 조회
+        List<Friend> friends = friendRepository.findAllByMember(member);
+
+        // FriendResponseDTO.of()를 활용하여 변환
+        return friends.stream().map(friend -> {
+            // 현재 회원이 속한 친구 관계에서 친구(파트너) 정보 추출
+            Member friendMember = friend.getPartner();
+
+            // 친구의 LocationDto 생성
+            LocationDto locationDto = friendMember.getLocation() != null
+                    ? LocationDto.builder()
+                    .lat(friendMember.getLocation().getY()) // 위도 추출
+                    .lng(friendMember.getLocation().getX()) // 경도 추출
+                    .build()
+                    : null;
+
+            // FriendResponseDTO.of() 메서드 활용
+            return FriendResponseDTO.of(friendMember, locationDto);
+        }).toList();
+    }
+
+
+
 
 
 }

--- a/src/test/java/life/walkit/server/friend/service/FriendServiceTest.java
+++ b/src/test/java/life/walkit/server/friend/service/FriendServiceTest.java
@@ -18,10 +18,7 @@ import life.walkit.server.friend.error.FriendException;
 import life.walkit.server.friend.repository.FriendRepository;
 import life.walkit.server.friend.repository.FriendRequestRepository;
 import life.walkit.server.global.util.GeoUtils;
-import life.walkit.server.member.dto.LocationDto;
 import life.walkit.server.member.entity.Member;
-import life.walkit.server.member.error.MemberException;
-import life.walkit.server.member.error.enums.MemberErrorCode;
 import life.walkit.server.member.repository.MemberRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -207,8 +204,8 @@ public class FriendServiceTest {
         Member memberB = memberRepository.save(createMember("user02@gmail.com", "User02"));
         Member memberC = memberRepository.save(createMember("user03@gmail.com", "User03"));
 
-        memberB.updateLocation(GeoUtils.toPoint(126.9780, 37.5665)); // 서울
-        memberC.updateLocation(GeoUtils.toPoint(129.0756, 35.1796)); // 부산
+        memberB.updateLocation(GeoUtils.toPoint(126.9780, 37.5665));
+        memberC.updateLocation(GeoUtils.toPoint(129.0756, 35.1796));
 
         memberRepository.save(memberB);
         memberRepository.save(memberC);
@@ -236,23 +233,6 @@ public class FriendServiceTest {
         assertThat(friendC.getLastLocation().getLat()).isEqualTo(35.1796);
         assertThat(friendC.getLastLocation().getLng()).isEqualTo(129.0756);
     }
-
-//    @Test
-//    @DisplayName("친구 목록 조회 테스트")
-//    void getFriends_success() {
-//        // given
-//        Member member = memberRepository.findByEmail("test@test.com")
-//                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-//
-//        // when
-//        List<FriendResponseDTO> friends = friendService.getFriends(member.getMemberId());
-//
-//        // then
-//        assertNotNull(friends);
-//        assertFalse(friends.isEmpty()); // 친구가 비어있지 않은지 확인
-//        assertEquals("친구 닉네임", friends.get(0).getNickname());
-//    }
-
 
 
 

--- a/src/test/java/life/walkit/server/friend/service/FriendServiceTest.java
+++ b/src/test/java/life/walkit/server/friend/service/FriendServiceTest.java
@@ -4,16 +4,24 @@ import static life.walkit.server.global.factory.GlobalTestFactory.createFriendRe
 import static life.walkit.server.global.factory.GlobalTestFactory.createMember;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
 import life.walkit.server.friend.dto.FriendRequestResponseDTO;
+import life.walkit.server.friend.dto.FriendResponseDTO;
 import life.walkit.server.friend.dto.ReceivedFriendResponse;
 import life.walkit.server.friend.dto.SentFriendResponse;
+import life.walkit.server.friend.entity.Friend;
 import life.walkit.server.friend.entity.FriendRequest;
 import life.walkit.server.friend.enums.FriendRequestStatus;
 import life.walkit.server.friend.error.FriendErrorCode;
 import life.walkit.server.friend.error.FriendException;
 import life.walkit.server.friend.repository.FriendRepository;
 import life.walkit.server.friend.repository.FriendRequestRepository;
+import life.walkit.server.global.util.GeoUtils;
+import life.walkit.server.member.dto.LocationDto;
 import life.walkit.server.member.entity.Member;
+import life.walkit.server.member.error.MemberException;
+import life.walkit.server.member.error.enums.MemberErrorCode;
 import life.walkit.server.member.repository.MemberRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,9 +52,9 @@ public class FriendServiceTest {
 
     @BeforeEach
     void setUp() {
-        memberA = memberRepository.save(createMember("a@email.com", "회원A"));
-        memberB = memberRepository.save(createMember("b@email.com", "회원B"));
-        memberC = memberRepository.save(createMember("c@email.com", "회원C"));
+        memberA = memberRepository.save(createMember("a@gmail.com", "회원A"));
+        memberB = memberRepository.save(createMember("b@gmail.com", "회원B"));
+        memberC = memberRepository.save(createMember("c@gmail.com", "회원C"));
     }
 
     @AfterEach
@@ -146,6 +154,61 @@ public class FriendServiceTest {
                 .isInstanceOf(FriendException.class)
                 .hasMessage(FriendErrorCode.UNAUTHORIZED_APPROVER.getMessage());
     }
+
+    @Test
+    @DisplayName("친구 목록 조회 성공")
+    void getFriendList_success() {
+        // Arrange - 테스트 데이터 생성 및 저장
+        Member memberA = memberRepository.save(createMember("user01@gmail.com", "User01"));
+        Member memberB = memberRepository.save(createMember("user02@gmail.com", "User02"));
+        Member memberC = memberRepository.save(createMember("user03@gmail.com", "User03"));
+
+        memberB.updateLocation(GeoUtils.toPoint(126.9780, 37.5665)); // 서울
+        memberC.updateLocation(GeoUtils.toPoint(129.0756, 35.1796)); // 부산
+
+        memberRepository.save(memberB);
+        memberRepository.save(memberC);
+
+        friendRepository.save(Friend.builder().member(memberA).partner(memberB).build());
+        friendRepository.save(Friend.builder().member(memberA).partner(memberC).build());
+
+        List<FriendResponseDTO> friends = friendService.getFriends(memberA.getMemberId());
+
+        assertThat(friends).hasSize(2);
+
+        // 친구 User02 검증
+        FriendResponseDTO friendB = friends.stream()
+                .filter(f -> f.getNickname().equals("User02"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(friendB.getLastLocation().getLat()).isEqualTo(37.5665);
+        assertThat(friendB.getLastLocation().getLng()).isEqualTo(126.9780);
+
+        // 친구 User03 검증
+        FriendResponseDTO friendC = friends.stream()
+                .filter(f -> f.getNickname().equals("User03"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(friendC.getLastLocation().getLat()).isEqualTo(35.1796);
+        assertThat(friendC.getLastLocation().getLng()).isEqualTo(129.0756);
+    }
+
+//    @Test
+//    @DisplayName("친구 목록 조회 테스트")
+//    void getFriends_success() {
+//        // given
+//        Member member = memberRepository.findByEmail("test@test.com")
+//                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+//
+//        // when
+//        List<FriendResponseDTO> friends = friendService.getFriends(member.getMemberId());
+//
+//        // then
+//        assertNotNull(friends);
+//        assertFalse(friends.isEmpty()); // 친구가 비어있지 않은지 확인
+//        assertEquals("친구 닉네임", friends.get(0).getNickname());
+//    }
+
 
 
 


### PR DESCRIPTION
## #️⃣연관된 이슈
#59 

## 📝작업 내용
- [x] 친구 목록 조회 API 구현
- [x] 친구 리스트 조회 응답 DTO 작성
- [x] 친구 목록 조회 서빈스 로직 구현
- [x] 각 친구에 대해 닉네임, 프로필 이미지, 상태(온라인/오프라인), 마지막 위치 정보 포함

### 스크린샷 (선택)
<img width="489" height="50" alt="스크린샷 2025-07-30 오후 12 23 07" src="https://github.com/user-attachments/assets/c74b1e63-ca18-4882-8da7-093dbcb82da3" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 친구 목록을 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
* **버그 수정**
  * 친구 요청 관련 API 경로가 복수형에서 단수형으로 변경되었습니다.
  * 친구 요청 승인 및 거절 API의 경로 및 파라미터 방식이 개선되었습니다.
  * 친구 요청 승인 응답에 승인된 친구 ID 정보가 포함되도록 변경되었습니다.
* **테스트**
  * 친구 목록 조회 기능에 대한 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->