### PR TITLE
Feat/#21: 산책 기록 API 구현 

### DIFF
--- a/src/main/java/life/walkit/server/walk/controller/WalkController.java
+++ b/src/main/java/life/walkit/server/walk/controller/WalkController.java
@@ -3,7 +3,6 @@ package life.walkit.server.walk.controller;
 import life.walkit.server.auth.dto.CustomMemberDetails;
 import life.walkit.server.global.response.BaseResponse;
 import life.walkit.server.walk.dto.enums.WalkResponse;
-import life.walkit.server.walk.repository.WalkRepository;
 import life.walkit.server.walk.service.WalkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -13,6 +12,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 
+// TODO: Swagger 표시
 @Controller("/api/walks")
 @RequiredArgsConstructor
 public class WalkController {

--- a/src/main/java/life/walkit/server/walk/controller/WalkController.java
+++ b/src/main/java/life/walkit/server/walk/controller/WalkController.java
@@ -8,11 +8,11 @@ import life.walkit.server.walk.service.WalkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
 // TODO: Swagger 표시
-@Controller("/api/walks")
+@RestController
+@RequestMapping("/api/walks")
 @RequiredArgsConstructor
 public class WalkController {
 

--- a/src/main/java/life/walkit/server/walk/controller/WalkController.java
+++ b/src/main/java/life/walkit/server/walk/controller/WalkController.java
@@ -72,4 +72,12 @@ public class WalkController {
         );
     }
 
+    @DeleteMapping("/{walkId}")
+    public ResponseEntity<BaseResponse> deleteWalk(@PathVariable("walkId") Long walkId) {
+
+        return BaseResponse.toResponseEntity(
+            WalkResponse.DELETE_WALK_SUCCESS,
+            walkService.deleteWalk(walkId)
+        );
+    }
 }

--- a/src/main/java/life/walkit/server/walk/controller/WalkController.java
+++ b/src/main/java/life/walkit/server/walk/controller/WalkController.java
@@ -1,0 +1,27 @@
+package life.walkit.server.walk.controller;
+
+import life.walkit.server.auth.dto.CustomMemberDetails;
+import life.walkit.server.global.response.BaseResponse;
+import life.walkit.server.walk.dto.enums.WalkResponse;
+import life.walkit.server.walk.service.WalkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller("/api/walks")
+@RequiredArgsConstructor
+public class WalkController {
+
+    private final WalkService walkService;
+
+    @PostMapping("/start")
+    public ResponseEntity<BaseResponse> startWalk(@AuthenticationPrincipal CustomMemberDetails member) {
+
+        return BaseResponse.toResponseEntity(
+            WalkResponse.START_WALK_SUCCESS,
+            walkService.startWalk(member.getMemberId())
+        );
+    }
+}

--- a/src/main/java/life/walkit/server/walk/controller/WalkController.java
+++ b/src/main/java/life/walkit/server/walk/controller/WalkController.java
@@ -45,4 +45,13 @@ public class WalkController {
             walkService.resumeWalk(walkId)
         );
     }
+
+    @PutMapping("/{walkId}/end")
+    public ResponseEntity<BaseResponse> endWalk(@PathVariable("walkId") Long walkId) {
+
+        return BaseResponse.toResponseEntity(
+            WalkResponse.RESUME_WALK_SUCCESS,
+            walkService.endWalk(walkId)
+        );
+    }
 }

--- a/src/main/java/life/walkit/server/walk/controller/WalkController.java
+++ b/src/main/java/life/walkit/server/walk/controller/WalkController.java
@@ -4,7 +4,6 @@ import life.walkit.server.auth.dto.CustomMemberDetails;
 import life.walkit.server.global.response.BaseResponse;
 import life.walkit.server.walk.dto.enums.WalkResponse;
 import life.walkit.server.walk.dto.request.WalkRequest;
-import life.walkit.server.walk.dto.response.WalkEventResponse;
 import life.walkit.server.walk.service.WalkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/life/walkit/server/walk/controller/WalkController.java
+++ b/src/main/java/life/walkit/server/walk/controller/WalkController.java
@@ -28,12 +28,21 @@ public class WalkController {
         );
     }
 
-    @PutMapping("/{walkId}/resume")
+    @PutMapping("/{walkId}/pause")
     public ResponseEntity<BaseResponse> pauseWalk(@PathVariable("walkId") Long walkId) {
 
         return BaseResponse.toResponseEntity(
             WalkResponse.PAUSE_WALK_SUCCESS,
             walkService.pauseWalk(walkId)
+        );
+    }
+
+    @PutMapping("/{walkId}/resume")
+    public ResponseEntity<BaseResponse> resumeWalk(@PathVariable("walkId") Long walkId) {
+
+        return BaseResponse.toResponseEntity(
+            WalkResponse.RESUME_WALK_SUCCESS,
+            walkService.resumeWalk(walkId)
         );
     }
 }

--- a/src/main/java/life/walkit/server/walk/controller/WalkController.java
+++ b/src/main/java/life/walkit/server/walk/controller/WalkController.java
@@ -3,12 +3,15 @@ package life.walkit.server.walk.controller;
 import life.walkit.server.auth.dto.CustomMemberDetails;
 import life.walkit.server.global.response.BaseResponse;
 import life.walkit.server.walk.dto.enums.WalkResponse;
+import life.walkit.server.walk.repository.WalkRepository;
 import life.walkit.server.walk.service.WalkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 
 @Controller("/api/walks")
 @RequiredArgsConstructor
@@ -22,6 +25,15 @@ public class WalkController {
         return BaseResponse.toResponseEntity(
             WalkResponse.START_WALK_SUCCESS,
             walkService.startWalk(member.getMemberId())
+        );
+    }
+
+    @PutMapping("/{walkId}/resume")
+    public ResponseEntity<BaseResponse> pauseWalk(@PathVariable("walkId") Long walkId) {
+
+        return BaseResponse.toResponseEntity(
+            WalkResponse.PAUSE_WALK_SUCCESS,
+            walkService.pauseWalk(walkId)
         );
     }
 }

--- a/src/main/java/life/walkit/server/walk/controller/WalkController.java
+++ b/src/main/java/life/walkit/server/walk/controller/WalkController.java
@@ -3,6 +3,7 @@ package life.walkit.server.walk.controller;
 import life.walkit.server.auth.dto.CustomMemberDetails;
 import life.walkit.server.global.response.BaseResponse;
 import life.walkit.server.walk.dto.enums.WalkResponse;
+import life.walkit.server.walk.dto.request.WalkRequest;
 import life.walkit.server.walk.service.WalkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 // TODO: Swagger 표시
 @Controller("/api/walks")
@@ -52,6 +54,15 @@ public class WalkController {
         return BaseResponse.toResponseEntity(
             WalkResponse.RESUME_WALK_SUCCESS,
             walkService.endWalk(walkId)
+        );
+    }
+
+    @PostMapping("/new")
+    public ResponseEntity<BaseResponse> createWalk(@RequestBody WalkRequest walkRequest) {
+
+        return BaseResponse.toResponseEntity(
+            WalkResponse.CREATE_WALK_SUCCESS,
+            walkService.createWalk(walkRequest)
         );
     }
 }

--- a/src/main/java/life/walkit/server/walk/controller/WalkController.java
+++ b/src/main/java/life/walkit/server/walk/controller/WalkController.java
@@ -4,6 +4,7 @@ import life.walkit.server.auth.dto.CustomMemberDetails;
 import life.walkit.server.global.response.BaseResponse;
 import life.walkit.server.walk.dto.enums.WalkResponse;
 import life.walkit.server.walk.dto.request.WalkRequest;
+import life.walkit.server.walk.dto.response.WalkEventResponse;
 import life.walkit.server.walk.service.WalkService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -49,7 +50,7 @@ public class WalkController {
     public ResponseEntity<BaseResponse> endWalk(@PathVariable("walkId") Long walkId) {
 
         return BaseResponse.toResponseEntity(
-            WalkResponse.RESUME_WALK_SUCCESS,
+            WalkResponse.END_WALK_SUCCESS,
             walkService.endWalk(walkId)
         );
     }

--- a/src/main/java/life/walkit/server/walk/controller/WalkController.java
+++ b/src/main/java/life/walkit/server/walk/controller/WalkController.java
@@ -9,10 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
 
 // TODO: Swagger 표시
 @Controller("/api/walks")
@@ -65,4 +62,14 @@ public class WalkController {
             walkService.createWalk(walkRequest)
         );
     }
+
+    @GetMapping("/walks")
+    public ResponseEntity<BaseResponse> getWalkList(@AuthenticationPrincipal CustomMemberDetails member) {
+
+        return BaseResponse.toResponseEntity(
+            WalkResponse.GET_WALK_LIST_SUCCESS,
+            walkService.getWalkList(member.getMemberId())
+        );
+    }
+
 }

--- a/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
+++ b/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
@@ -11,7 +11,8 @@ public enum WalkResponse implements Response {
     PAUSE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 일시정지 성공"),
     RESUME_WALK_SUCCESS(HttpStatus.OK, "산책 기록 재개"),
     CREATE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 등록 생성 성공"),
-    GET_WALK_LIST_SUCCESS(HttpStatus.OK, "산책 기록 리스트 조회 성공");
+    GET_WALK_LIST_SUCCESS(HttpStatus.OK, "산책 기록 리스트 조회 성공"),
+    DELETE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 삭제 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
+++ b/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
@@ -10,7 +10,8 @@ public enum WalkResponse implements Response {
     START_WALK_SUCCESS(HttpStatus.OK, "산책 기록 시작 성공"),
     PAUSE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 일시정지 성공"),
     RESUME_WALK_SUCCESS(HttpStatus.OK, "산책 기록 재개"),
-    CREATE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 등록 생성 성공");
+    CREATE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 등록 생성 성공"),
+    GET_WALK_LIST_SUCCESS(HttpStatus.OK, "산책 기록 리스트 조회 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
+++ b/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 public enum WalkResponse implements Response {
 
     START_WALK_SUCCESS(HttpStatus.OK, "산책 기록 시작 성공"),
-    PAUSE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 일시정지 성공");
+    PAUSE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 일시정지 성공"),
+    RESUME_WALK_SUCCESS(HttpStatus.OK, "산책 기록 재개");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
+++ b/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
@@ -9,7 +9,8 @@ public enum WalkResponse implements Response {
 
     START_WALK_SUCCESS(HttpStatus.OK, "산책 기록 시작 성공"),
     PAUSE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 일시정지 성공"),
-    RESUME_WALK_SUCCESS(HttpStatus.OK, "산책 기록 재개");
+    RESUME_WALK_SUCCESS(HttpStatus.OK, "산책 기록 재개"),
+    CREATE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 등록 생성 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
+++ b/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum WalkResponse implements Response {
 
-    START_WALK_SUCCESS(HttpStatus.OK, "산책 기록 시작 성공");
+    START_WALK_SUCCESS(HttpStatus.OK, "산책 기록 시작 성공"),
+    PAUSE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 일시정지 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
+++ b/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
@@ -10,6 +10,7 @@ public enum WalkResponse implements Response {
     START_WALK_SUCCESS(HttpStatus.OK, "산책 기록 시작 성공"),
     PAUSE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 일시정지 성공"),
     RESUME_WALK_SUCCESS(HttpStatus.OK, "산책 기록 재개"),
+    END_WALK_SUCCESS(HttpStatus.OK, "산책 종료 성공"),
     CREATE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 등록 생성 성공"),
     GET_WALK_LIST_SUCCESS(HttpStatus.OK, "산책 기록 리스트 조회 성공"),
     DELETE_WALK_SUCCESS(HttpStatus.OK, "산책 기록 삭제 성공");

--- a/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
+++ b/src/main/java/life/walkit/server/walk/dto/enums/WalkResponse.java
@@ -1,0 +1,24 @@
+package life.walkit.server.walk.dto.enums;
+
+import life.walkit.server.global.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum WalkResponse implements Response {
+
+    START_WALK_SUCCESS(HttpStatus.OK, "산책 기록 시작 성공");
+
+    private final HttpStatus httpStatus;
+    private final String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/life/walkit/server/walk/dto/request/WalkRequest.java
+++ b/src/main/java/life/walkit/server/walk/dto/request/WalkRequest.java
@@ -1,17 +1,44 @@
 package life.walkit.server.walk.dto.request;
 
+import jakarta.validation.constraints.*;
+import org.hibernate.validator.constraints.URL;
+
 import java.util.List;
 
+
 public record WalkRequest(
+    // 수정 시에만 사용되므로 생성/수정 DTO 분리를 권장합니다.
     Long walkId,
+
+    @Size(
+        max = 100,
+        message = "산책 제목은 100자를 초과할 수 없습니다."
+    )
+    @NotBlank(message = "산책 제목은 필수입니다.")
     String walkTitle,
+
+    @NotNull(message = "총 시간은 필수입니다.")
+    @Positive(message = "총 시간은 양수여야 합니다.")
     Integer totalTime,
+
+    @NotNull(message = "총 거리는 필수입니다.")
+    @Positive(message = "총 거리는 양수여야 합니다.")
     Double totalDistance,
+
+    @NotNull(message = "속도는 필수입니다.")
+    @Positive(message = "속도는 양수여야 합니다.")
     Double pace,
+
+    @NotEmpty(message = "경로 데이터는 필수입니다.")
     List<List<Double>> path,
+
+    @NotEmpty(message = "시작 지점은 필수입니다.")
     List<Double> startPoint,
+
     Long eventId,
     String eventType,
+
+    @URL(message = "유효한 URL 형식이 아닙니다.")
     String routeUrl
 ) {
 

--- a/src/main/java/life/walkit/server/walk/dto/request/WalkRequest.java
+++ b/src/main/java/life/walkit/server/walk/dto/request/WalkRequest.java
@@ -1,0 +1,18 @@
+package life.walkit.server.walk.dto.request;
+
+import java.util.List;
+
+public record WalkRequest(
+    Long walkId,
+    String walkTitle,
+    Integer totalTime,
+    Double totalDistance,
+    Double pace,
+    List<List<Double>> path,
+    List<Double> startPoint,
+    Long eventId,
+    String eventType,
+    String routeUrl
+) {
+
+}

--- a/src/main/java/life/walkit/server/walk/dto/response/WalkCreateResponse.java
+++ b/src/main/java/life/walkit/server/walk/dto/response/WalkCreateResponse.java
@@ -1,0 +1,7 @@
+package life.walkit.server.walk.dto.response;
+
+public record WalkCreateResponse(
+    Long walkId
+) {
+    
+}

--- a/src/main/java/life/walkit/server/walk/dto/response/WalkDeleteResponse.java
+++ b/src/main/java/life/walkit/server/walk/dto/response/WalkDeleteResponse.java
@@ -1,0 +1,7 @@
+package life.walkit.server.walk.dto.response;
+
+public record WalkDeleteResponse(
+    Long walkId,
+    Long memberId
+) {
+}

--- a/src/main/java/life/walkit/server/walk/dto/response/WalkEventResponse.java
+++ b/src/main/java/life/walkit/server/walk/dto/response/WalkEventResponse.java
@@ -1,0 +1,25 @@
+package life.walkit.server.walk.dto.response;
+
+import life.walkit.server.walk.entity.WalkingSession;
+import life.walkit.server.walk.entity.enums.EventType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record WalkEventResponse(
+    Long walkId,
+    Long eventId,
+    EventType eventType,
+    LocalDateTime eventTime
+) {
+    public static WalkEventResponse from(WalkingSession walkingSession) {
+        return WalkEventResponse.builder()
+            .walkId(walkingSession.getWalk().getWalkId())
+            .eventId(walkingSession.getEventId())
+            .eventType(walkingSession.getEventType())
+            .eventTime(walkingSession.getEventTime())
+            .build();
+    }
+}

--- a/src/main/java/life/walkit/server/walk/dto/response/WalkEventResponse.java
+++ b/src/main/java/life/walkit/server/walk/dto/response/WalkEventResponse.java
@@ -3,7 +3,6 @@ package life.walkit.server.walk.dto.response;
 import life.walkit.server.walk.entity.WalkingSession;
 import life.walkit.server.walk.entity.enums.EventType;
 import lombok.Builder;
-import lombok.Getter;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/life/walkit/server/walk/dto/response/WalkListResponse.java
+++ b/src/main/java/life/walkit/server/walk/dto/response/WalkListResponse.java
@@ -1,0 +1,16 @@
+package life.walkit.server.walk.dto.response;
+
+public record WalkListResponse(
+    Long walkId,
+    Long trailId,
+    Long eventId,
+    String eventTime,
+    Long trailImageId,
+    String routeImageUrl,
+    Double totalDistance,
+    String totalTime,
+    String pace,
+    String title,
+    Boolean isUploaded
+) {
+}

--- a/src/main/java/life/walkit/server/walk/entity/Walk.java
+++ b/src/main/java/life/walkit/server/walk/entity/Walk.java
@@ -5,7 +5,6 @@ import life.walkit.server.member.entity.Member;
 import life.walkit.server.path.entity.Path;
 import life.walkit.server.trail.entity.Trail;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +14,6 @@ import java.time.Duration;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Table(name = "walk")
 public class Walk {
 

--- a/src/main/java/life/walkit/server/walk/entity/Walk.java
+++ b/src/main/java/life/walkit/server/walk/entity/Walk.java
@@ -5,6 +5,7 @@ import life.walkit.server.member.entity.Member;
 import life.walkit.server.path.entity.Path;
 import life.walkit.server.trail.entity.Trail;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +15,7 @@ import java.time.Duration;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Table(name = "walk")
 public class Walk {
 
@@ -67,6 +69,20 @@ public class Walk {
         nullable = false
     )
     private Boolean isUploaded;
+
+    public void updateWalkDetails(
+        String walkTitle,
+        Path path,
+        Double totalDistance,
+        Duration totalTime,
+        Double pace
+    ) {
+        this.walkTitle = walkTitle;
+        this.path = path;
+        this.totalDistance = totalDistance;
+        this.totalTime = totalTime;
+        this.pace = pace;
+    }
 
     @Builder
     public Walk(

--- a/src/main/java/life/walkit/server/walk/entity/Walk.java
+++ b/src/main/java/life/walkit/server/walk/entity/Walk.java
@@ -39,8 +39,7 @@ public class Walk {
         orphanRemoval = true
     )
     @JoinColumn(
-        name = "path_id",
-        nullable = false
+        name = "path_id"
     )
     private Path path;
 
@@ -48,20 +47,17 @@ public class Walk {
     private String walkTitle;
 
     @Column(
-        name = "total_distance",
-        nullable = false
+        name = "total_distance"
     )
     private Double totalDistance;
 
     @Column(
-        name = "total_time",
-        nullable = false
+        name = "total_time"
     )
     private Duration totalTime;
 
     @Column(
-        name = "pace",
-        nullable = false
+        name = "pace"
     )
     private Double pace;
 

--- a/src/main/java/life/walkit/server/walk/entity/WalkingSession.java
+++ b/src/main/java/life/walkit/server/walk/entity/WalkingSession.java
@@ -42,11 +42,9 @@ public class WalkingSession {
 
     @Builder
     public WalkingSession(
-        Long eventId,
         Walk walk,
         EventType eventType
     ) {
-        this.eventId = eventId;
         this.walk = walk;
         this.eventType = eventType;
         this.eventTime = LocalDateTime.now();

--- a/src/main/java/life/walkit/server/walk/error/enums/WalkErrorCode.java
+++ b/src/main/java/life/walkit/server/walk/error/enums/WalkErrorCode.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum WalkErrorCode implements ErrorCode {
+    INVALID_WALK_SESSION(HttpStatus.BAD_REQUEST, "유효하지 않은 산책 세션입니다."),
     WALK_START_FAILED(HttpStatus.BAD_REQUEST, "산책 기록 시작에 실패했습니다"),
     WALK_PAUSE_FAILED(HttpStatus.BAD_REQUEST, "산책 기록 일시정지에 실패했습니다"),
     WALK_RESUME_FAILED(HttpStatus.BAD_REQUEST, "산책 기록 재개에 실패했습니다"),

--- a/src/main/java/life/walkit/server/walk/error/enums/WalkErrorCode.java
+++ b/src/main/java/life/walkit/server/walk/error/enums/WalkErrorCode.java
@@ -15,7 +15,8 @@ public enum WalkErrorCode implements ErrorCode {
     WALK_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 산책 기록입니다"),
     WALK_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 완료된 산책 기록입니다"),
     WALK_NOT_IN_PROGRESS(HttpStatus.BAD_REQUEST, "진행 중인 산책 기록이 아닙니다"),
-    WALK_ALREADY_PAUSED(HttpStatus.BAD_REQUEST, "이미 일시정지된 산책 기록입니다");
+    WALK_ALREADY_PAUSED(HttpStatus.BAD_REQUEST, "이미 일시정지된 산책 기록입니다"),
+    WALK_NOT_PAUSED(HttpStatus.BAD_REQUEST, "일시정지 상태인 산책만 재개할 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/life/walkit/server/walk/error/enums/WalkException.java
+++ b/src/main/java/life/walkit/server/walk/error/enums/WalkException.java
@@ -1,0 +1,12 @@
+package life.walkit.server.walk.error.enums;
+
+import life.walkit.server.global.error.core.BaseException;
+import life.walkit.server.global.error.core.ErrorCode;
+
+public class WalkException extends BaseException {
+
+    public WalkException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+}

--- a/src/main/java/life/walkit/server/walk/repository/WalkingSessionRepository.java
+++ b/src/main/java/life/walkit/server/walk/repository/WalkingSessionRepository.java
@@ -3,9 +3,13 @@ package life.walkit.server.walk.repository;
 import life.walkit.server.walk.entity.Walk;
 import life.walkit.server.walk.entity.WalkingSession;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface WalkingSessionRepository extends JpaRepository<WalkingSession, Long> {
     List<WalkingSession> findByWalk(Walk walk);
+
+    Optional<WalkingSession> findFirstByWalkOrderByEventTimeDesc(Walk walk);
 }

--- a/src/main/java/life/walkit/server/walk/service/WalkService.java
+++ b/src/main/java/life/walkit/server/walk/service/WalkService.java
@@ -9,6 +9,7 @@ import life.walkit.server.trailwalkimage.entity.TrailWalkImage;
 import life.walkit.server.trailwalkimage.repository.TrailWalkImageRepository;
 import life.walkit.server.walk.dto.request.WalkRequest;
 import life.walkit.server.walk.dto.response.WalkCreateResponse;
+import life.walkit.server.walk.dto.response.WalkDeleteResponse;
 import life.walkit.server.walk.dto.response.WalkEventResponse;
 import life.walkit.server.walk.dto.response.WalkListResponse;
 import life.walkit.server.walk.entity.Walk;
@@ -19,6 +20,7 @@ import life.walkit.server.walk.error.enums.WalkException;
 import life.walkit.server.walk.repository.WalkRepository;
 import life.walkit.server.walk.repository.WalkingSessionRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import org.locationtech.jts.geom.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -173,6 +175,16 @@ public class WalkService {
             .toList();
     }
 
+    @Transactional
+    public WalkDeleteResponse deleteWalk(Long walkId) {
+        Walk foundWalk = findByWalkId(walkId);
+        walkRepository.delete(foundWalk);
+        Long foundWalkId = foundWalk.getWalkId();
+        Long memberId = foundWalk.getMember().getMemberId();
+
+        return new WalkDeleteResponse(foundWalkId, memberId);
+    }
+
     private WalkListResponse mapToWalkListResponse(Walk walk) {
         WalkingSession latestSession = findLatestSessionByWalk(walk);
         List<TrailWalkImage> trailWalkImages = trailWalkImageRepository.findByWalk(walk);
@@ -186,17 +198,17 @@ public class WalkService {
         }
 
         return new WalkListResponse(
-                walk.getWalkId(),
-                walk.getTrail() != null ? walk.getTrail().getTrailId() : null,
-                latestSession.getEventId(),
-                latestSession.getEventTime().toString(),
-                imageId,
-                imageUrl,
-                walk.getTotalDistance(),
-                walk.getTotalTime() != null ? walk.getTotalTime().toString() : null,
-                walk.getPace() != null ? walk.getPace().toString() : null,
-                walk.getWalkTitle(),
-                walk.getIsUploaded()
+            walk.getWalkId(),
+            walk.getTrail() != null ? walk.getTrail().getTrailId() : null,
+            latestSession.getEventId(),
+            latestSession.getEventTime().toString(),
+            imageId,
+            imageUrl,
+            walk.getTotalDistance(),
+            walk.getTotalTime() != null ? walk.getTotalTime().toString() : null,
+            walk.getPace() != null ? walk.getPace().toString() : null,
+            walk.getWalkTitle(),
+            walk.getIsUploaded()
         );
     }
 

--- a/src/main/java/life/walkit/server/walk/service/WalkService.java
+++ b/src/main/java/life/walkit/server/walk/service/WalkService.java
@@ -230,14 +230,14 @@ public class WalkService {
         return geometryFactory.createLineString(coordinates);
     }
 
-    private Point createPath(List<Double> pathPoint) {
+    private Point createPath(List<Double> coordinates) {
         GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
 
-        if (pathPoint == null || pathPoint.size() < 2) {
+        if (coordinates == null || coordinates.size() < 2) {
             throw new IllegalArgumentException("좌표 데이터는 최소 2개(경도, 위도)가 필요합니다.");
         }
 
-        Coordinate coordinate = new Coordinate(pathPoint.get(0), pathPoint.get(1));
+        Coordinate coordinate = new Coordinate(coordinates.get(0), coordinates.get(1));
         return geometryFactory.createPoint(coordinate);
     }
 

--- a/src/main/java/life/walkit/server/walk/service/WalkService.java
+++ b/src/main/java/life/walkit/server/walk/service/WalkService.java
@@ -1,0 +1,53 @@
+package life.walkit.server.walk.service;
+
+import life.walkit.server.member.entity.Member;
+import life.walkit.server.member.error.MemberException;
+import life.walkit.server.member.error.enums.MemberErrorCode;
+import life.walkit.server.member.repository.MemberRepository;
+import life.walkit.server.walk.dto.response.WalkEventResponse;
+import life.walkit.server.walk.entity.Walk;
+import life.walkit.server.walk.entity.WalkingSession;
+import life.walkit.server.walk.entity.enums.EventType;
+import life.walkit.server.walk.repository.WalkRepository;
+import life.walkit.server.walk.repository.WalkingSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class WalkService {
+
+    private final MemberRepository memberRepository;
+    private final WalkRepository walkRepository;
+    private final WalkingSessionRepository walkingSessionRepository;
+
+    @Transactional
+    public WalkEventResponse startWalk(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        Walk walk = walkRepository.save(
+            Walk.builder()
+                .member(member)
+                .trail(null)
+                .path(null)
+                .walkTitle(null)
+                .totalDistance(null)
+                .totalTime(null)
+                .pace(null)
+                .isUploaded(false)
+                .build()
+        );
+
+        WalkingSession walkingSession = walkingSessionRepository.save(
+            WalkingSession.builder()
+                .walk(walk)
+                .eventType(EventType.START)
+                .build()
+        );
+
+        return WalkEventResponse.from(walkingSession);
+    }
+}

--- a/src/main/java/life/walkit/server/walk/service/WalkService.java
+++ b/src/main/java/life/walkit/server/walk/service/WalkService.java
@@ -83,13 +83,12 @@ public class WalkService {
         Walk walk = findByWalkId(walkId);
 
         // PAUSE 일때만 시작 가능
-        walkingSessionRepository.findByWalk(walk)
-            .stream()
-            .filter(item -> item.getEventType() != EventType.PAUSE)
-            .findFirst()
-            .ifPresent(invalidItem -> {
-                throw new WalkException(WalkErrorCode.WALK_NOT_PAUSED);
-            });
+        WalkingSession latestSession = walkingSessionRepository.findFirstByWalkOrderByEventTimeDesc(walk)
+            .orElseThrow(() -> new WalkException(WalkErrorCode.WALK_NOT_FOUND));
+
+        if (latestSession.getEventType() != EventType.PAUSE) {
+            throw new WalkException(WalkErrorCode.WALK_NOT_PAUSED);
+        }
 
         WalkingSession walkingSession = walkingSessionRepository.save(
             WalkingSession.builder()

--- a/src/main/java/life/walkit/server/walk/service/WalkService.java
+++ b/src/main/java/life/walkit/server/walk/service/WalkService.java
@@ -20,14 +20,13 @@ import life.walkit.server.walk.error.enums.WalkException;
 import life.walkit.server.walk.repository.WalkRepository;
 import life.walkit.server.walk.repository.WalkingSessionRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.java.Log;
 import org.locationtech.jts.geom.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.Optional;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -127,6 +126,11 @@ public class WalkService {
         Walk walk = findByWalkId(walkRequest.walkId());
 
         WalkingSession latestSessionByWalk = findLatestSessionByWalk(walk);
+
+        // 마지막 eventId가 일치하지 않을 경우 에러 생성
+        if (!Objects.equals(latestSessionByWalk.getEventId(), walkRequest.eventId())) {
+            throw new WalkException(WalkErrorCode.INVALID_WALK_SESSION);
+        }
 
         // 중간 세션이 끝난 상태가 아닐시 끝낸다.
         if (latestSessionByWalk.getEventType() != EventType.END) {

--- a/src/main/java/life/walkit/server/walk/service/WalkService.java
+++ b/src/main/java/life/walkit/server/walk/service/WalkService.java
@@ -209,11 +209,18 @@ public class WalkService {
             imageId,
             imageUrl,
             walk.getTotalDistance(),
-            walk.getTotalTime() != null ? walk.getTotalTime().toString() : null,
-            walk.getPace() != null ? walk.getPace().toString() : null,
+            walk.getTotalTime() != null ? formatDuration(walk.getTotalTime()) : null,
+            walk.getPace() != null ? String.format("%.2f", walk.getPace()) : null,
             walk.getWalkTitle(),
             walk.getIsUploaded()
         );
+    }
+
+    private String formatDuration(Duration duration) {
+        long hours = duration.toHours();
+        long minutes = duration.toMinutesPart();
+        long seconds = duration.toSecondsPart();
+        return String.format("%02d:%02d:%02d", hours, minutes, seconds);
     }
 
     private LineString createLineString(List<List<Double>> pathPoints) {

--- a/src/test/java/life/walkit/server/walk/service/WalkServiceTest.java
+++ b/src/test/java/life/walkit/server/walk/service/WalkServiceTest.java
@@ -27,9 +27,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 
 import static life.walkit.server.global.factory.GlobalTestFactory.createMember;
+import static life.walkit.server.global.factory.GlobalTestFactory.createWalk;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -266,4 +270,18 @@ public class WalkServiceTest {
         assertThat(walkList).isEmpty();
     }
 
+    @Test
+    @DisplayName("산책 기록 삭제 성공")
+    void deleteWalk_success() {
+        // given
+        Walk savedWalk = walkRepository.save(Walk.builder().member(member).isUploaded(false).build());
+        Long walkId = savedWalk.getWalkId();
+
+        // when
+        walkService.deleteWalk(walkId);
+
+        // then
+        Optional<Walk> foundWalkOptional = walkRepository.findById(walkId);
+        assertThat(foundWalkOptional).isEmpty();
+    }
 }

--- a/src/test/java/life/walkit/server/walk/service/WalkServiceTest.java
+++ b/src/test/java/life/walkit/server/walk/service/WalkServiceTest.java
@@ -1,0 +1,47 @@
+package life.walkit.server.walk.service;
+
+import life.walkit.server.member.entity.Member;
+import life.walkit.server.member.repository.MemberRepository;
+import life.walkit.server.walk.dto.response.WalkEventResponse;
+import life.walkit.server.walk.entity.enums.EventType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static life.walkit.server.global.factory.GlobalTestFactory.createMember;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+public class WalkServiceTest {
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    WalkService walkService;
+
+    Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(createMember("a@email.com", "회원A"));
+    }
+
+    @Test
+    @DisplayName("산책 기록 시작 성공")
+    void startWalk_success() {
+        WalkEventResponse walkEventResponse = walkService.startWalk(member.getMemberId());
+
+        assertThat(walkEventResponse.eventType()).isEqualTo(EventType.START);
+        assertThat(walkEventResponse.eventId()).isNotNull();
+        assertThat(walkEventResponse.walkId()).isNotNull();
+    }
+
+
+}

--- a/src/test/java/life/walkit/server/walk/service/WalkServiceTest.java
+++ b/src/test/java/life/walkit/server/walk/service/WalkServiceTest.java
@@ -133,7 +133,7 @@ public class WalkServiceTest {
 
     @Test
     @DisplayName("산책 기록이 이미 멈춤 상태일시 에러")
-    void resumeWalk_alreadyPaused_throwsException() {
+    void endWalk_alreadyCompleted_throwsException() {
         // given
         WalkEventResponse walkEventResponse = walkService.startWalk(member.getMemberId()); // 산책 기록 생성
         WalkEventResponse walkEventResponseEnd = walkService.endWalk(walkEventResponse.walkId());

--- a/src/test/java/life/walkit/server/walk/service/WalkServiceTest.java
+++ b/src/test/java/life/walkit/server/walk/service/WalkServiceTest.java
@@ -78,7 +78,7 @@ public class WalkServiceTest {
     }
 
     @Test
-    @DisplayName("산책 기록 재개")
+    @DisplayName("산책 기록 재개 성공")
     void resumeWalk_success() {
         WalkEventResponse walkEventResponse = walkService.startWalk(member.getMemberId()); // 산책 기록 생성
         WalkEventResponse walkEventResponsePause = walkService.pauseWalk(walkEventResponse.walkId()); // 산책 기록 멈춤
@@ -90,7 +90,7 @@ public class WalkServiceTest {
     }
 
     @Test
-    @DisplayName("산책 기록 멈춘 상태가 아닐시 에러")
+    @DisplayName("산책 기록이 멈춘 상태가 아닐시 에러")
     void resumeWalk_notPausedState_throwsException() {
         // given
         WalkEventResponse walkEventResponse = walkService.startWalk(member.getMemberId()); // 산책 기록 생성
@@ -104,5 +104,33 @@ public class WalkServiceTest {
         assertThat(walkException.getErrorCode()).isEqualTo(WalkErrorCode.WALK_NOT_PAUSED);
     }
 
+    @Test
+    @DisplayName("산책 기록 종료 성공")
+    void endWalk_success() {
+        // given
+        WalkEventResponse walkEventResponse = walkService.startWalk(member.getMemberId());
+        WalkEventResponse walkEventResponseEnd = walkService.endWalk(walkEventResponse.walkId());
+
+        // when & then
+        assertThat(walkEventResponseEnd.eventType()).isEqualTo(EventType.END);
+        assertThat(walkEventResponseEnd.eventId()).isNotNull();
+        assertThat(walkEventResponseEnd.walkId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("산책 기록이 이미 멈춤 상태일시 에러")
+    void resumeWalk_alreadyPaused_throwsException() {
+        // given
+        WalkEventResponse walkEventResponse = walkService.startWalk(member.getMemberId()); // 산책 기록 생성
+        WalkEventResponse walkEventResponseEnd = walkService.endWalk(walkEventResponse.walkId());
+
+        // when
+        WalkException walkException = assertThrows(WalkException.class, () ->
+            walkService.endWalk(walkEventResponseEnd.walkId())
+        );
+
+        // then
+        assertThat(walkException.getErrorCode()).isEqualTo(WalkErrorCode.WALK_ALREADY_COMPLETED);
+    }
 
 }

--- a/src/test/java/life/walkit/server/walk/service/WalkServiceTest.java
+++ b/src/test/java/life/walkit/server/walk/service/WalkServiceTest.java
@@ -2,8 +2,11 @@ package life.walkit.server.walk.service;
 
 import life.walkit.server.member.entity.Member;
 import life.walkit.server.member.repository.MemberRepository;
+import life.walkit.server.walk.dto.enums.WalkResponse;
 import life.walkit.server.walk.dto.response.WalkEventResponse;
+import life.walkit.server.walk.entity.Walk;
 import life.walkit.server.walk.entity.enums.EventType;
+import life.walkit.server.walk.repository.WalkRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +16,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static life.walkit.server.global.factory.GlobalTestFactory.createMember;
+import static life.walkit.server.global.factory.GlobalTestFactory.createWalk;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -24,13 +28,29 @@ public class WalkServiceTest {
     MemberRepository memberRepository;
 
     @Autowired
+    WalkRepository walkRepository;
+
+    @Autowired
     WalkService walkService;
 
     Member member;
+    Walk walk;
 
     @BeforeEach
     void setUp() {
         member = memberRepository.save(createMember("a@email.com", "회원A"));
+        Walk walk = walkRepository.save(
+            createWalk(
+                member,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false
+            )
+        );
     }
 
     @Test
@@ -41,6 +61,17 @@ public class WalkServiceTest {
         assertThat(walkEventResponse.eventType()).isEqualTo(EventType.START);
         assertThat(walkEventResponse.eventId()).isNotNull();
         assertThat(walkEventResponse.walkId()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("산책 기록 멈춤 성공")
+    void paseWalk_success() {
+        WalkEventResponse walkEventResponse = walkService.startWalk(member.getMemberId()); // 산책 기록 생성
+        WalkEventResponse walkEventResponsePause = walkService.pauseWalk(walkEventResponse.walkId());
+
+        assertThat(walkEventResponsePause.eventType()).isEqualTo(EventType.PAUSE);
+        assertThat(walkEventResponsePause.eventId()).isNotNull();
+        assertThat(walkEventResponsePause.walkId()).isNotNull();
     }
 
 

--- a/src/test/java/life/walkit/server/walk/service/WalkServiceTest.java
+++ b/src/test/java/life/walkit/server/walk/service/WalkServiceTest.java
@@ -2,20 +2,31 @@ package life.walkit.server.walk.service;
 
 import life.walkit.server.member.entity.Member;
 import life.walkit.server.member.repository.MemberRepository;
-import life.walkit.server.walk.dto.enums.WalkResponse;
+import life.walkit.server.path.repository.PathRepository;
+import life.walkit.server.walk.dto.request.WalkRequest;
 import life.walkit.server.walk.dto.response.WalkEventResponse;
 import life.walkit.server.walk.entity.Walk;
+import life.walkit.server.walk.entity.WalkingSession;
 import life.walkit.server.walk.entity.enums.EventType;
 import life.walkit.server.walk.error.enums.WalkErrorCode;
 import life.walkit.server.walk.error.enums.WalkException;
 import life.walkit.server.walk.repository.WalkRepository;
+import life.walkit.server.walk.repository.WalkingSessionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
 
 import static life.walkit.server.global.factory.GlobalTestFactory.createMember;
 import static life.walkit.server.global.factory.GlobalTestFactory.createWalk;
@@ -36,8 +47,13 @@ public class WalkServiceTest {
     @Autowired
     WalkService walkService;
 
+    @Autowired
+    PathRepository pathRepository;
+
     Member member;
     Walk walk;
+    @Autowired
+    private WalkingSessionRepository walkingSessionRepository;
 
     @BeforeEach
     void setUp() {
@@ -131,6 +147,60 @@ public class WalkServiceTest {
 
         // then
         assertThat(walkException.getErrorCode()).isEqualTo(WalkErrorCode.WALK_ALREADY_COMPLETED);
+    }
+
+    @Test
+    @DisplayName("산책 기록 저장 성공")
+    void createWalk_success() {
+        // given
+        List<List<Double>> path = List.of(
+            List.of(126.75791835403612, 37.662510637017874),
+            List.of(126.75790151956403, 37.66262761454681),
+            List.of(126.75789029658108, 37.662723861742975),
+            List.of(126.75790900155192, 37.66283343532169),
+            List.of(126.75795763447428, 37.662935605134706),
+            List.of(126.75809792174988, 37.66306886989648),
+            List.of(126.75818770560676, 37.66312069501714)
+        );
+
+        List<Double> startPoint = List.of(
+            126.75791835403612, 37.662510637017874
+        );
+
+        WalkEventResponse walkEventResponse = walkService.startWalk(member.getMemberId()); // 기록 생성
+        WalkRequest walkRequest = new WalkRequest(
+            walkEventResponse.walkId(),
+            "2025-07-28의 산책기록",
+            3600,
+            5635.2534,
+            5.636,
+            path,
+            startPoint,
+            walkEventResponse.eventId(),
+            "END",
+            "example.test.url"
+        );
+
+        GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+        Coordinate[] coordinates = path.stream()
+            .map(p -> new Coordinate(p.get(0), p.get(1)))
+            .toArray(Coordinate[]::new);
+        LineString lineString = geometryFactory.createLineString(coordinates);
+        Point point = geometryFactory.createPoint(new Coordinate(startPoint.get(0), startPoint.get(1)));
+
+        // when
+        walkService.createWalk(walkRequest);
+        Walk foundWalk = walkRepository.findById(walkEventResponse.walkId()).get();
+        WalkingSession walkingSession = walkingSessionRepository.findFirstByWalkOrderByEventTimeDesc(foundWalk).get();
+
+        // then
+        assertThat(foundWalk.getTotalDistance()).isEqualTo(5635.2534);
+        assertThat(foundWalk.getPace()).isEqualTo(5.636);
+        assertThat(foundWalk.getTotalTime().getSeconds()).isEqualTo(3600);
+        assertThat(walkingSession.getEventType()).isEqualTo(EventType.END);
+        assertThat(foundWalk.getPath().getPath()).isEqualTo(lineString);
+        assertThat(foundWalk.getPath().getPoint()).isEqualTo(point);
+        assertThat(foundWalk.getWalkTitle()).isEqualTo("2025-07-28의 산책기록");
     }
 
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#21 
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
산책 기록 구현

### 스크린샷

<details>
    <summary>열기</summary>
<img width="462" height="272" alt="스크린샷 2025-07-31 오후 3 20 45" src="https://github.com/user-attachments/assets/fffbf103-45c1-4014-9b34-556af9228fd3" />



</details>

## 💬기타
Swagger는 컨트롤러 변경부분 때문에 병합 후 리펙토링 바로 들갈꺼 같습니다.

엔티티 변경이 여러번 일어난 상태라서 저번주 금요일에 끝나야할 작업이 지금 끝났습니다.
초반에는 이런 상황을 위해서 추후에 다음 프로젝트에서는 기간이 긴 프로젝트가 아니면 레포지스토리 테스트를 넘기고 하면 좋을꺼 같습니다.

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 산책 시작, 일시정지, 재개, 종료, 생성, 조회, 삭제 등 산책 관리 기능이 추가되었습니다.
  * 산책 생성 시 경로, 거리, 시간, 페이스 등 상세 정보 입력 및 저장이 가능합니다.
  * 산책 목록 조회 시 각 산책의 최신 이벤트, 이미지, 메타데이터 확인이 가능합니다.

* **버그 수정**
  * 일시정지 상태가 아닌 산책을 재개하려 할 때 적절한 오류 메시지가 제공됩니다.

* **테스트**
  * 산책 기능의 전체 라이프사이클(시작, 일시정지, 재개, 종료, 생성, 조회, 삭제)에 대한 통합 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->