### PR TITLE
refactor/#71: Swagger 설명 추가 

### DIFF
--- a/src/main/java/life/walkit/server/walk/controller/WalkController.java
+++ b/src/main/java/life/walkit/server/walk/controller/WalkController.java
@@ -2,6 +2,7 @@ package life.walkit.server.walk.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import life.walkit.server.auth.dto.CustomMemberDetails;
 import life.walkit.server.global.response.BaseResponse;
 import life.walkit.server.walk.dto.enums.WalkResponse;
@@ -29,7 +30,10 @@ public class WalkController {
 
     private final WalkService walkService;
 
-    @Operation(summary = "산책 기록 시작", description = "새로운 산책 기록을 시작하고, 생성된 walkId와 eventId를 반환합니다.")
+    @Operation(
+        summary = "산책 기록 시작",
+        description = "새로운 산책 기록을 시작하고, 생성된 walkId와 eventId를 반환합니다."
+    )
     @PostMapping("/start")
     public ResponseEntity<BaseResponse<WalkEventResponse>> startWalk(@AuthenticationPrincipal CustomMemberDetails member) {
         return BaseResponse.toResponseEntity(
@@ -38,7 +42,10 @@ public class WalkController {
         );
     }
 
-    @Operation(summary = "산책 기록 일시정지", description = "진행 중인 산책을 일시정지합니다.")
+    @Operation(
+        summary = "산책 기록 일시정지",
+        description = "진행 중인 산책을 일시정지합니다."
+    )
     @PutMapping("/{walkId}/pause")
     public ResponseEntity<BaseResponse<WalkEventResponse>> pauseWalk(@PathVariable("walkId") Long walkId) {
         return BaseResponse.toResponseEntity(
@@ -47,7 +54,10 @@ public class WalkController {
         );
     }
 
-    @Operation(summary = "산책 기록 재개", description = "일시정지된 산책을 다시 시작합니다.")
+    @Operation(
+        summary = "산책 기록 재개",
+        description = "일시정지된 산책을 다시 시작합니다."
+    )
     @PutMapping("/{walkId}/resume")
     public ResponseEntity<BaseResponse<WalkEventResponse>> resumeWalk(@PathVariable("walkId") Long walkId) {
         return BaseResponse.toResponseEntity(
@@ -56,7 +66,10 @@ public class WalkController {
         );
     }
 
-    @Operation(summary = "산책 기록 종료", description = "진행 중인 산책을 최종 종료합니다.")
+    @Operation(
+        summary = "산책 기록 종료",
+        description = "진행 중인 산책을 최종 종료합니다."
+    )
     @PutMapping("/{walkId}/end")
     public ResponseEntity<BaseResponse<WalkEventResponse>> endWalk(@PathVariable("walkId") Long walkId) {
         return BaseResponse.toResponseEntity(
@@ -65,17 +78,23 @@ public class WalkController {
         );
     }
 
-    @Operation(summary = "산책 기록 저장", description = "종료된 산책의 상세 정보(경로, 시간, 거리 등)를 저장합니다.")
+    @Operation(
+        summary = "산책 기록 저장",
+        description = "종료된 산책의 상세 정보(경로, 시간, 거리 등)를 저장합니다."
+    )
     @PostMapping("/new")
-    public ResponseEntity<BaseResponse<WalkCreateResponse>> createWalk(@RequestBody WalkRequest walkRequest) {
+    public ResponseEntity<BaseResponse<WalkCreateResponse>> createWalk(@Valid @RequestBody WalkRequest walkRequest) {
         return BaseResponse.toResponseEntity(
             WalkResponse.CREATE_WALK_SUCCESS,
             walkService.createWalk(walkRequest)
         );
     }
 
-    @Operation(summary = "산책 기록 목록 조회", description = "자신이 기록한 모든 산책 기록의 목록을 조회합니다.")
-    @GetMapping("/walks")
+    @Operation(
+        summary = "산책 기록 목록 조회",
+        description = "자신이 기록한 모든 산책 기록의 목록을 조회합니다."
+    )
+    @GetMapping
     public ResponseEntity<BaseResponse<List<WalkListResponse>>> getWalkList(@AuthenticationPrincipal CustomMemberDetails member) {
         return BaseResponse.toResponseEntity(
             WalkResponse.GET_WALK_LIST_SUCCESS,
@@ -83,7 +102,10 @@ public class WalkController {
         );
     }
 
-    @Operation(summary = "산책 기록 삭제", description = "특정 산책 기록을 삭제합니다.")
+    @Operation(
+        summary = "산책 기록 삭제",
+        description = "특정 산책 기록을 삭제합니다."
+    )
     @DeleteMapping("/{walkId}")
     public ResponseEntity<BaseResponse<WalkDeleteResponse>> deleteWalk(@PathVariable("walkId") Long walkId) {
         return BaseResponse.toResponseEntity(


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
#71 

## 📝작업 내용
스웨거 추가 및 BaseResponse 제네릭 설정 완료
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

<details>
    <summary>열기</summary>
<img width="1501" height="503" alt="스크린샷 2025-07-31 오후 5 40 57" src="https://github.com/user-attachments/assets/6c96d4a6-e1b7-482b-b1d8-b79e2b571e28" />



</details>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * 산책 기록 API 엔드포인트에 대한 OpenAPI(Swagger) 문서가 추가되어, 각 기능별 설명과 그룹화가 제공됩니다.

* **Refactor**
  * 모든 산책 관련 API 응답이 보다 구체적이고 명확한 타입으로 개선되어, 반환 데이터의 구조가 명확해졌습니다.
  * 산책 생성 요청에 대한 유효성 검사가 추가되었으며, 산책 목록 조회 경로가 간소화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->