### PR TITLE
Feat/#80: 친구 목록 조회 기능 구현

### DIFF
--- a/src/main/java/life/walkit/server/friend/controller/FriendController.java
+++ b/src/main/java/life/walkit/server/friend/controller/FriendController.java
@@ -82,12 +82,13 @@ public class FriendController {
 
     @GetMapping
     @Operation(summary = "친구 목록 조회", description = "현재 사용자의 친구 목록을 조회합니다.")
-    public ResponseEntity<BaseResponse<List<FriendResponseDTO>>> getFriends(
+    public ResponseEntity<BaseResponse<FriendListResponseDTO>> getFriends(
             @AuthenticationPrincipal CustomMemberDetails member
     ) {
         return BaseResponse.toResponseEntity(
                 FriendResponse.LIST_SUCCESS,
-                friendService.getFriends(member.getMemberId()));
+                friendService.getFriends(member.getMemberId())
+        );
     }
 
     @Operation(summary = "친구 삭제하기", description = "친구 관계를 삭제합니다.")

--- a/src/main/java/life/walkit/server/friend/dto/FriendListResponseDTO.java
+++ b/src/main/java/life/walkit/server/friend/dto/FriendListResponseDTO.java
@@ -1,0 +1,16 @@
+package life.walkit.server.friend.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.util.List;
+
+@Getter
+@Builder
+public class FriendListResponseDTO {
+    private int total;
+    private int online;
+    private int offline;
+    private List<FriendResponseDTO> onlineFriends;
+    private List<FriendResponseDTO> offlineFriends;
+}
+

--- a/src/main/java/life/walkit/server/friend/dto/FriendResponseDTO.java
+++ b/src/main/java/life/walkit/server/friend/dto/FriendResponseDTO.java
@@ -15,25 +15,15 @@ public class FriendResponseDTO {
     private String nickname;
     private String profile;
     private MemberStatus memberStatus;
-    private LocationDto lastLocation;
 
-    public static FriendResponseDTO of(Member member) {
-        // LocationDto 생성 로직을 내부로 이동
-        LocationDto locationDto = Optional.ofNullable(member.getLocation())
-                .map(location -> LocationDto.builder()
-                        .lat(location.getY()) // 위도
-                        .lng(location.getX()) // 경도
-                        .build())
-                .orElse(null);
-
+    public static FriendResponseDTO of(Member member, String statusText) {
         return FriendResponseDTO.builder()
                 .friendId(member.getMemberId())
                 .nickname(member.getNickname())
                 .profile(Optional.ofNullable(member.getProfileImage())
                         .map(ProfileImage::getProfileImage)
-                        .orElse("")) // null-safe 프로필 처리
+                        .orElse("")) // null-safe
                 .memberStatus(member.getStatus())
-                .lastLocation(locationDto)
                 .build();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
#80 

## 📝작업 내용
- [ ] 친구 목록 전체 조회 시 친구의 상태를 갱신 한 후 친구 목록을 조회하도록 수정
- [ ] 상태에 따른 친구 목록 조회 기능 수정

### 스크린샷 (선택)
<img width="552" height="97" alt="스크린샷 2025-08-05 오전 10 59 48" src="https://github.com/user-attachments/assets/19edb801-82c4-4816-b8cf-0b8df91f67dd" />



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
