### PR TITLE
Feat/#83: 친구 위치 조회 기능 구현

### DIFF
--- a/src/main/java/life/walkit/server/friend/controller/FriendController.java
+++ b/src/main/java/life/walkit/server/friend/controller/FriendController.java
@@ -113,6 +113,17 @@ public class FriendController {
         );
     }
 
+    @Operation(summary = "친구 위치 조회", description = "친구들의 위치 정보를 조회합니다.")
+    @GetMapping("/location")
+    public ResponseEntity<BaseResponse<List<FriendLocationResponseDTO>>> getFriendLocations(
+            @AuthenticationPrincipal CustomMemberDetails member
+    ) {
+        return BaseResponse.toResponseEntity(
+                FriendResponse.LOCATION_LIST_SUCCESS,
+                friendService.getFriendLocations(member.getMemberId())
+        );
+    }
+
 
 }
 

--- a/src/main/java/life/walkit/server/friend/dto/FriendLocationResponseDTO.java
+++ b/src/main/java/life/walkit/server/friend/dto/FriendLocationResponseDTO.java
@@ -25,10 +25,12 @@ public class FriendLocationResponseDTO {
                 .profile(Optional.ofNullable(member.getProfileImage())
                         .map(ProfileImage::getProfileImage)
                         .orElse("")) // null-safe
-                .location(LocationDto.builder()
-                        .lng(member.getLocation().getX()) // 경도
-                        .lat(member.getLocation().getY()) // 위도
-                        .build())
+                .location(Optional.ofNullable(member.getLocation())
+                        .map(loc -> LocationDto.builder()
+                                .lng(loc.getX())
+                                .lat(loc.getY())
+                                .build())
+                         .orElse(null))
                 .build();
     }
 

--- a/src/main/java/life/walkit/server/friend/dto/FriendLocationResponseDTO.java
+++ b/src/main/java/life/walkit/server/friend/dto/FriendLocationResponseDTO.java
@@ -1,0 +1,37 @@
+package life.walkit.server.friend.dto;
+
+import life.walkit.server.member.dto.LocationDto;
+import life.walkit.server.member.entity.Member;
+import life.walkit.server.member.entity.ProfileImage;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Optional;
+
+@Getter
+@Builder
+public class FriendLocationResponseDTO {
+    private Long friendId;       // 친구 ID
+    private Long memberId;       // 멤버 ID
+    private String nickname;     // 닉네임
+    private String profile;      // 프로필 이미지 URL
+    private LocationDto location; // 위치 정보 DTO
+
+    public static FriendLocationResponseDTO of(Member member, Long friendId) {
+        return FriendLocationResponseDTO.builder()
+                .friendId(friendId)
+                .memberId(member.getMemberId())
+                .nickname(member.getNickname())
+                .profile(Optional.ofNullable(member.getProfileImage())
+                        .map(ProfileImage::getProfileImage)
+                        .orElse("")) // null-safe
+                .location(LocationDto.builder()
+                        .lng(member.getLocation().getX()) // 경도
+                        .lat(member.getLocation().getY()) // 위도
+                        .build())
+                .build();
+    }
+
+
+
+}

--- a/src/main/java/life/walkit/server/friend/enums/FriendResponse.java
+++ b/src/main/java/life/walkit/server/friend/enums/FriendResponse.java
@@ -9,7 +9,8 @@ public enum FriendResponse implements Response {
 
     LIST_SUCCESS(HttpStatus.OK, "친구 목록을 조회 성공"),
     STATUS_LIST_SUCCESS(HttpStatus.OK, "상태에 따른 친구 목록 조회 성공"),
-    DELETE_SUCCESS(HttpStatus.OK, "친구 삭제 성공");
+    DELETE_SUCCESS(HttpStatus.OK, "친구 삭제 성공"),
+    LOCATION_LIST_SUCCESS(HttpStatus.OK, "친구 위치 정보 조회 성공");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/life/walkit/server/friend/service/FriendService.java
+++ b/src/main/java/life/walkit/server/friend/service/FriendService.java
@@ -232,6 +232,12 @@ public class FriendService {
         // 산책 중인 친구(WALKING 상태)의 위치만 필터링하여 반환
         return friends.stream()
                 .map(Friend::getPartner)
+                .map(partner -> {
+                    // 각 친구의 상태 갱신
+                    MemberStatus updatedStatus = memberService.refreshMemberStatus(partner.getMemberId());
+                    partner.updateStatus(updatedStatus);
+                    return partner;
+                })
                 .filter(partner -> partner.getStatus() == MemberStatus.WALKING)
                 .map(partner -> {
                     // 위치가 없는 경우 null-safe 처리


### PR DESCRIPTION
## #️⃣연관된 이슈
#83 

## 📝작업 내용
- [ ] 산책(WALKING) 상태의 친구들의 위치 정보를 조회하는 API 추가
- [ ] 사용자는 인증된 상태에서 자신의 친구 중 산책 중인 친구의 위치 정보를 확인할 수 있음
- [ ] 조회 시, 위치가 없는 친구는 `null`로 처리


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 친구들의 위치 정보를 조회할 수 있는 새로운 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 친구 상태별 조회 시 최신 상태를 반영하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->