### PR TITLE
Feat/#118: ReceivedFriendResponse에 친구요청 ID 필드 추가

### DIFF
--- a/src/main/java/life/walkit/server/friend/dto/ReceivedFriendResponse.java
+++ b/src/main/java/life/walkit/server/friend/dto/ReceivedFriendResponse.java
@@ -10,13 +10,14 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ReceivedFriendResponse {
-
+    private Long friendRequestId;
     private String senderNickname;
     private String profile;
     private FriendRequestStatus requestStatus;
 
-    public static ReceivedFriendResponse of(Member sender, FriendRequestStatus requestStatus) {
+    public static ReceivedFriendResponse of(Long friendRequestId, Member sender, FriendRequestStatus requestStatus) {
         return ReceivedFriendResponse.builder()
+                .friendRequestId(friendRequestId)
                 .senderNickname(sender.getNickname())
                 .profile(Optional.ofNullable(sender.getProfileImage())
                         .map(ProfileImage::getProfileImage)

--- a/src/main/java/life/walkit/server/friend/service/FriendService.java
+++ b/src/main/java/life/walkit/server/friend/service/FriendService.java
@@ -1,6 +1,5 @@
 package life.walkit.server.friend.service;
 
-import life.walkit.server.auth.repository.LastActiveRepository;
 import life.walkit.server.friend.dto.*;
 import life.walkit.server.friend.entity.Friend;
 import life.walkit.server.member.dto.LocationDto;
@@ -31,7 +30,6 @@ public class FriendService {
     private final FriendRequestRepository friendRequestRepository;
     private final FriendRepository friendRepository;
     private final MemberRepository memberRepository;
-    private final LastActiveRepository lastActiveRepository;
     private final MemberService memberService;
 
     public FriendRequestResponseDTO sendFriendRequest(Long senderId, String targetNickname) {
@@ -89,7 +87,10 @@ public class FriendService {
         List<FriendRequest> requests = friendRequestRepository.findByReceiverAndStatus(receiver, FriendRequestStatus.PENDING);
 
         return requests.stream()
-                .map(request -> ReceivedFriendResponse.of(request.getSender(), request.getStatus()))
+                .map(request -> ReceivedFriendResponse.of(
+                        request.getFriendRequestId(),
+                        request.getSender(),
+                        request.getStatus()))
                 .toList();
     }
 

--- a/src/test/java/life/walkit/server/friend/service/FriendServiceTest.java
+++ b/src/test/java/life/walkit/server/friend/service/FriendServiceTest.java
@@ -3,9 +3,6 @@ package life.walkit.server.friend.service;
 import static life.walkit.server.global.factory.GlobalTestFactory.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.when;
-
-import life.walkit.server.auth.repository.LastActiveRepository;
 import life.walkit.server.friend.dto.*;
 import life.walkit.server.friend.entity.Friend;
 import life.walkit.server.friend.entity.FriendRequest;
@@ -14,11 +11,9 @@ import life.walkit.server.friend.error.FriendErrorCode;
 import life.walkit.server.friend.error.FriendException;
 import life.walkit.server.friend.repository.FriendRepository;
 import life.walkit.server.friend.repository.FriendRequestRepository;
-import life.walkit.server.global.util.GeoUtils;
 import life.walkit.server.member.entity.Member;
 import life.walkit.server.member.entity.enums.MemberStatus;
 import life.walkit.server.member.repository.MemberRepository;
-import life.walkit.server.member.service.MemberService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,11 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
-import java.util.Optional;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -40,15 +31,11 @@ public class FriendServiceTest {
     @Autowired
     private FriendService friendService;
     @Autowired
-    private MemberService memberService;
-    @Autowired
     private MemberRepository memberRepository;
     @Autowired
     private FriendRepository friendRepository;
     @Autowired
     private FriendRequestRepository friendRequestRepository;
-    @Autowired
-    private LastActiveRepository lastActiveRepository;
 
     private Member memberA;
     private Member memberB;


### PR DESCRIPTION
## #️⃣연관된 이슈
#118 

## 📝작업 내용
- 승인 거절 시 친구 요청을 구분하기 위해 친구 요청 목록 DTO에 친구요청 ID 필드를 추가합니다.

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 친구 요청 목록에서 각 요청의 고유 ID를 확인할 수 있도록 개선되었습니다.

* **스타일**
  * 불필요한 의존성과 임포트가 테스트 코드에서 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->